### PR TITLE
Parse request body params only if content type is incorrect

### DIFF
--- a/spec/param_parser_spec.cr
+++ b/spec/param_parser_spec.cr
@@ -18,8 +18,36 @@ describe "ParamParser" do
       hasan = env.params["hasan"]
       "Hello #{name} #{hasan} #{age}"
     end
-    request = HTTP::Request.new("POST", "/?hasan=cemal", body: "name=serdar&age=99")
+
+    request = HTTP::Request.new(
+      "POST",
+      "/?hasan=cemal",
+      body: "name=serdar&age=99",
+      headers: HTTP::Headers{"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
     params = Kemal::ParamParser.new(route, request).parse
     params.should eq({"hasan" => "cemal", "name" => "serdar", "age" => "99"})
+  end
+
+  context "when content type is incorrect" do
+    it "does not parse request body" do
+      route = Route.new "POST", "/" do |env|
+        name = env.params["name"]
+        age = env.params["age"]
+        hasan = env.params["hasan"]
+        "Hello #{name} #{hasan} #{age}"
+      end
+
+      request = HTTP::Request.new(
+        "POST",
+        "/?hasan=cemal",
+        body: "name=serdar&age=99",
+        headers: HTTP::Headers{"Content-Type": "text/plain"},
+      )
+
+      params = Kemal::ParamParser.new(route, request).parse
+      params.should eq({"hasan" => "cemal"})
+    end
   end
 end


### PR DESCRIPTION
This PR ensures, that body params are parsed only when needed.

/cc @sdogruyol 