### PR TITLE
Add Halt Macros for JSON, HTML, and Plain Text Content-Types

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -68,6 +68,87 @@ describe "Macros" do
     end
   end
 
+  describe "#halt_json" do
+    it "can break block and sets content_type to application/json" do
+      get "/" do |env|
+        env.response.content_type = "text/plain"
+        halt_json env, 400, %({"language":"crystal"})
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(400)
+      client_response.content_type.should eq("application/json")
+      JSON.parse(client_response.body)["language"].should eq("crystal")
+    end
+
+    it "can break block with halt macro using default values" do
+      get "/" do |env|
+        env.response.content_type = "text/plain"
+        halt_json env
+        "world"
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.content_type.should eq("application/json")
+      client_response.body.should eq("")
+    end
+  end
+
+  describe "#halt_html" do
+    it "can break block and sets content_type to text/html" do
+      get "/" do |env|
+        env.response.content_type = "text/plain"
+        halt_html env, 404, "<h1>Not Found</h1>"
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(404)
+      client_response.content_type.should eq("text/html")
+      client_response.body.should eq("<h1>Not Found</h1>")
+    end
+
+    it "can break block with halt macro using default values" do
+      get "/" do |env|
+        env.response.content_type = "text/plain"
+        halt_html env
+        "world"
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.content_type.should eq("text/html")
+      client_response.body.should eq("")
+    end
+  end
+
+  describe "#halt_plain" do
+    it "can break block and sets content_type to text/plain" do
+      get "/" do |env|
+        env.response.content_type = "text/html"
+        halt_plain env, 404, "Not Found"
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(404)
+      client_response.content_type.should eq("text/plain")
+      client_response.body.should eq("Not Found")
+    end
+
+    it "can break block with halt macro using default values" do
+      get "/" do |env|
+        env.response.content_type = "text/html"
+        halt_plain env
+        "world"
+      end
+      request = HTTP::Request.new("GET", "/")
+      client_response = call_request_on_app(request)
+      client_response.status_code.should eq(200)
+      client_response.content_type.should eq("text/plain")
+      client_response.body.should eq("")
+    end
+  end
+
   describe "#headers" do
     it "can add headers" do
       get "/headers" do |env|

--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -76,3 +76,39 @@ macro halt(env, status_code = 200, response = "")
   {{env}}.response.close
   next
 end
+
+# Halt execution with the current context, setting Content-Type to application/json
+# Returns 200 and an empty response by default.
+#
+#   halt_json env, status_code: 403, response: %({"msg": "Forbidden"})
+macro halt_json(env, status_code = 200, response = "")
+  {{env}}.response.status_code = {{status_code}}
+  {{env}}.response.content_type "application/json"
+  {{env}}.response.print {{response}}
+  {{env}}.response.close
+  next
+end
+
+# Halt execution with the current context, setting Content-Type to text/html
+# Returns 200 and an empty response by default.
+#
+#   halt env, status_code: 403, response: "<h1>Forbidden</h1>"
+macro halt_html(env, status_code = 200, response = "")
+  {{env}}.response.status_code = {{status_code}}
+  {{env}}.response.content_type "text/html"
+  {{env}}.response.print {{response}}
+  {{env}}.response.close
+  next
+end
+
+# Halt execution with the current context, setting Content-Type to text/plain
+# Returns 200 and an empty response by default.
+#
+#   halt env, status_code: 403, response: "Forbidden"
+macro halt_plain(env, status_code = 200, response = "")
+  {{env}}.response.status_code = {{status_code}}
+  {{env}}.response.content_type "text/plain"
+  {{env}}.response.print {{response}}
+  {{env}}.response.close
+  next
+end

--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -82,33 +82,24 @@ end
 #
 #   halt_json env, status_code: 403, response: %({"msg": "Forbidden"})
 macro halt_json(env, status_code = 200, response = "")
-  {{env}}.response.status_code = {{status_code}}
   {{env}}.response.content_type = "application/json"
-  {{env}}.response.print {{response}}
-  {{env}}.response.close
-  next
+  halt {{env}}, {{status_code}}, {{response}}
 end
 
 # Halt execution with the current context, setting Content-Type to text/html
 # Returns 200 and an empty response by default.
 #
-#   halt env, status_code: 403, response: "<h1>Forbidden</h1>"
+#   halt_html env, status_code: 403, response: "<h1>Forbidden</h1>"
 macro halt_html(env, status_code = 200, response = "")
-  {{env}}.response.status_code = {{status_code}}
   {{env}}.response.content_type = "text/html"
-  {{env}}.response.print {{response}}
-  {{env}}.response.close
-  next
+  halt {{env}}, {{status_code}}, {{response}}
 end
 
 # Halt execution with the current context, setting Content-Type to text/plain
 # Returns 200 and an empty response by default.
 #
-#   halt env, status_code: 403, response: "Forbidden"
+#   halt_plain env, status_code: 403, response: "Forbidden"
 macro halt_plain(env, status_code = 200, response = "")
-  {{env}}.response.status_code = {{status_code}}
   {{env}}.response.content_type = "text/plain"
-  {{env}}.response.print {{response}}
-  {{env}}.response.close
-  next
+  halt {{env}}, {{status_code}}, {{response}}
 end

--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -83,7 +83,7 @@ end
 #   halt_json env, status_code: 403, response: %({"msg": "Forbidden"})
 macro halt_json(env, status_code = 200, response = "")
   {{env}}.response.status_code = {{status_code}}
-  {{env}}.response.content_type "application/json"
+  {{env}}.response.content_type = "application/json"
   {{env}}.response.print {{response}}
   {{env}}.response.close
   next
@@ -95,7 +95,7 @@ end
 #   halt env, status_code: 403, response: "<h1>Forbidden</h1>"
 macro halt_html(env, status_code = 200, response = "")
   {{env}}.response.status_code = {{status_code}}
-  {{env}}.response.content_type "text/html"
+  {{env}}.response.content_type = "text/html"
   {{env}}.response.print {{response}}
   {{env}}.response.close
   next
@@ -107,7 +107,7 @@ end
 #   halt env, status_code: 403, response: "Forbidden"
 macro halt_plain(env, status_code = 200, response = "")
   {{env}}.response.status_code = {{status_code}}
-  {{env}}.response.content_type "text/plain"
+  {{env}}.response.content_type = "text/plain"
   {{env}}.response.print {{response}}
   {{env}}.response.close
   next


### PR DESCRIPTION
Adds `halt_json`, `halt_html`, `halt_plain` macros that do the same as `halt` but also set the Content-Type.

Inspired by Express, where you can easily respond with the content-type.

**Express.js Example**

```javascript
router.get('/', (req, res) => {
  const myArray = [{"name": "sam"}];
  if (myArray.length < 1)
    res.status(400).send('Empty array').end();
  else
    res.json(myArray).end();
});
```

**Kemal Example**

Now, in kemal, instead of doing this:

```ruby
get "/" do |env|
  if my_object.nil?
    env.response.content_type = "text/plain"
    halt env, 400, "Nil object. Cannot parse"
  else
    env.response.content_type = "application/json"
    halt env, 200, my_object.to_json
  end
end
```

You can do this:

```ruby
get "/" do |env|
  if my_object.nil?
    halt_plain env, 400, "Nil object. Cannot parse"
  else
    halt_json env, 200, my_object.to_json
  end
end
```