### PR TITLE
Update Radix to latest and lock pessimistically

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.17.1
 dependencies:
   radix:
     github: luislavena/radix
-    version: 0.3.4
+    version: ~> 0.3.5
   kilt:
     github: jeromegn/kilt
     version: 0.3.3


### PR DESCRIPTION
Radix project follows a Semantic Versioning approach which avoids introducing breaking changes in PATCH releases.

With this in consideration, it is safe to use pessimistic operator to indicate the version of Radix to use.

Closes #261