### PR TITLE
Use https for loading crystal setup script

### DIFF
--- a/_docs/getting_started.md
+++ b/_docs/getting_started.md
@@ -16,7 +16,7 @@ brew install crystal-lang
 ### Debian / Ubuntu
 
 ```
-curl http://dist.crystal-lang.org/apt/setup.sh | sudo bash
+curl https://dist.crystal-lang.org/apt/setup.sh | sudo bash
 sudo apt-get install crystal
 ```
 


### PR DESCRIPTION
The official documentation of crystal also uses https to load the setup script. Using http alone is way too unsecure.