### PR TITLE
Add configurable startup logging as a block

### DIFF
--- a/spec/run_spec.cr
+++ b/spec/run_spec.cr
@@ -1,0 +1,20 @@
+require "./spec_helper"
+
+describe "Run" do
+  it "runs a code block after starting" do
+    Kemal.config.env = "test"
+    make_me_true = false
+    Kemal.run do
+      make_me_true = true
+      Kemal.stop
+    end
+    make_me_true.should eq true
+  end
+
+  it "runs without a block being specified" do
+    Kemal.config.env = "test"
+    Kemal.run
+    Kemal.config.running.should eq true
+    Kemal.stop
+  end
+end

--- a/spec/run_spec.cr
+++ b/spec/run_spec.cr
@@ -17,4 +17,14 @@ describe "Run" do
     Kemal.config.running.should eq true
     Kemal.stop
   end
+
+  it "runs with just a block" do
+    Kemal.config.env = "test"
+    make_me_true = false
+    Kemal.run do
+      make_me_true = true
+      Kemal.stop
+    end
+    make_me_true.should eq true
+  end
 end

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -50,11 +50,11 @@ module Kemal
           halt env, 404
         end
       end
-
-      yield config
-      config.running = true
-      config.server.listen
     end
+
+    config.running = true
+    yield config
+    config.server.listen if config.env != "test"
   end
 
   def self.stop

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -12,6 +12,12 @@ module Kemal
     end
   end
 
+  # Overload of self.run to allow just a block
+  def self.run(&block)
+    self.run nil &block
+  end
+   
+
   # The command to run a `Kemal` application.
   # The port can be given to `#run` but is optional.
   # If not given Kemal will use `Kemal::Config#port`

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -4,10 +4,18 @@ require "./kemal/*"
 require "./kemal/helpers/*"
 
 module Kemal
+
+  # Overload of self.run with the default startup logging
+  def self.run(port = nil)
+    self.run port do
+      log "[#{config.env}] Kemal is ready to lead at #{config.scheme}://#{config.host_binding}:#{config.port}\n"
+    end
+  end
+
   # The command to run a `Kemal` application.
   # The port can be given to `#run` but is optional.
   # If not given Kemal will use `Kemal::Config#port`
-  def self.run(port = nil)
+  def self.run(port = nil, &block)
     Kemal::CLI.new
     config = Kemal.config
     config.setup
@@ -43,7 +51,7 @@ module Kemal
         end
       end
 
-      log "[#{config.env}] Kemal is ready to lead at #{config.scheme}://#{config.host_binding}:#{config.port}\n"
+      yield config
       config.running = true
       config.server.listen
     end


### PR DESCRIPTION
Allow `kemal.run` to optionally take a code block to change the post-start logging, or run any other post-start code at that time. This fixes part of #290, wasn't sure how to handle the shut-down text.

I hope I'm not missing some glaringly obvious configuration here that already allows for this!