### PR TITLE
Allow for disabling the shutdown message

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -31,10 +31,10 @@ describe "Config" do
 
   it "toggles the shutdown message" do
     config = Kemal.config
-    config.shutdown_message false
-    config.shutdown_message?.should eq false
-    config.shutdown_message true
-    config.shutdown_message?.should eq true
+    config.shutdown_message = false
+    config.shutdown_message.should eq false
+    config.shutdown_message = true
+    config.shutdown_message.should eq true
   end
 
   it "adds custom options" do

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -29,6 +29,14 @@ describe "Config" do
     config.handlers.size.should eq(6)
   end
 
+  it "toggles the shutdown message" do
+    config = Kemal.config
+    config.shutdown_message false
+    config.shutdown_message?.should eq false
+    config.shutdown_message true
+    config.shutdown_message?.should eq true
+  end
+
   it "adds custom options" do
     config = Kemal.config
     ARGV.push("--test")

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -27,7 +27,7 @@ module Kemal
     # Test environment doesn't need to have signal trap, built-in images, and logging.
     unless config.env == "test"
       Signal::INT.trap {
-        log "Kemal is going to take a rest!\n" if config.shutdown_message?
+        log "Kemal is going to take a rest!\n" if config.shutdown_message
         Kemal.stop
         exit
       }

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -27,7 +27,7 @@ module Kemal
     # Test environment doesn't need to have signal trap, built-in images, and logging.
     unless config.env == "test"
       Signal::INT.trap {
-        log "Kemal is going to take a rest!\n"
+        log "Kemal is going to take a rest!\n" if config.shutdown_message?
         Kemal.stop
         exit
       }

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -32,6 +32,7 @@ module Kemal
       @custom_handler_position = 4
       @default_handlers_setup = false
       @running = false
+      @shutdown_message = true
     end
 
     def logger
@@ -40,6 +41,14 @@ module Kemal
 
     def logger=(logger : Kemal::BaseLogHandler)
       @logger = logger
+    end
+
+    def shutdown_message(status : Bool)
+      @shutdown_message = status
+    end
+
+    def shutdown_message?
+      @shutdown_message
     end
 
     def scheme

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -15,7 +15,8 @@ module Kemal
     {% end %}
 
     property host_binding, ssl, port, env, public_folder, logging, running,
-      always_rescue, serve_static : (Bool | Hash(String, Bool)), server, extra_options
+      always_rescue, serve_static : (Bool | Hash(String, Bool)), server, extra_options,
+      shutdown_message
 
     def initialize
       @host_binding = "0.0.0.0"
@@ -41,14 +42,6 @@ module Kemal
 
     def logger=(logger : Kemal::BaseLogHandler)
       @logger = logger
-    end
-
-    def shutdown_message(status : Bool)
-      @shutdown_message = status
-    end
-
-    def shutdown_message?
-      @shutdown_message
     end
 
     def scheme


### PR DESCRIPTION
By default, it is still on, but config.shutdown_message can toggle it off:

```crystal
# Disable the shutdown message
Kemal.config.shutdown_message false
```