### PR TITLE
Make file upload accesible from context.

### DIFF
--- a/src/kemal/file_upload.cr
+++ b/src/kemal/file_upload.cr
@@ -1,0 +1,12 @@
+# :nodoc:
+struct FileUpload
+  getter tmpfile : Tempfile
+  getter tmpfile_path : String
+  getter filename : String
+  getter meta : HTTP::FormData::FileMetadata
+  getter headers : HTTP::Headers
+
+  def initialize(@tmpfile, @tmpfile_path, @meta, @headers)
+    @filename = @meta.filename.not_nil!
+  end
+end

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -72,33 +72,3 @@ end
 def gzip(status : Bool = false)
   add_handler HTTP::DeflateHandler.new if status
 end
-
-# :nodoc:
-struct UploadFile
-  getter field : String
-  getter data : IO::Delimited
-  getter meta : HTTP::FormData::FileMetadata
-  getter headers : HTTP::Headers
-
-  def initialize(@field, @data, @meta, @headers)
-  end
-end
-
-# Parses a multipart/form-data request. Yields an `UploadFile` object with `field`, `data`, `meta`, `headers` fields.
-# Consider the example below taking two image uploads as image1, image2. To get the relevant data
-# for each file you can use simple `if/switch` conditionals.
-#
-#   post "/upload" do |env|
-#     parse_multipart(env) do |f|
-#       image1 = f.data if f.field == "image1"
-#       image2 = f.data if f.field == "image2"
-#       puts f.meta
-#       puts f.headers
-#       "Upload complete"
-#     end
-#   end
-def parse_multipart(env)
-  HTTP::FormData.parse(env.request) do |field, data, meta, headers|
-    yield UploadFile.new field, data, meta, headers
-  end
-end

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -34,11 +34,19 @@ module Kemal
       raise Kemal::Exceptions::RouteNotFound.new(context) unless context.route_defined?
       route = context.route_lookup.payload.as(Route)
       content = route.handler.call(context)
+    ensure
+      remove_tmpfiles(context)
       if Kemal.config.error_handlers.has_key?(context.response.status_code)
         raise Kemal::Exceptions::CustomException.new(context)
       end
       context.response.print(content)
       context
+    end
+
+    private def remove_tmpfiles(context)
+      context.params.files.each do |field, file|
+        File.delete(file.tmpfile_path) if ::File.exists?(file.tmpfile_path)
+      end
     end
 
     private def radix_path(method : String, path)


### PR DESCRIPTION
This makes file upload easier to handle. Thanks @crisward for giving me the idea 🙏 

I made some small modification to his PR #305 for this.

```crystal
post "/upload" do |env|
  file = env.params.files["image1"].tmpfile
  file_path = ::File.join [Kemal.config.public_folder, "uploads/", file.filename]
  File.open(file_path, "w") do |f|
    IO.copy(file, f)
  end
  "Upload ok"
end
```

With this you can access the underlying upload file with `env.params.files["upload_key"].tmpfile`.
There's also other properties as

- filename
- tmpfile_path
- meta
- headers

