### PR TITLE
path_starts_with... method naming

### DIFF
--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -9,13 +9,13 @@ FILTER_METHODS = %w(get post put patch delete options all)
 
 {% for method in HTTP_METHODS %}
   def {{method.id}}(path, &block : HTTP::Server::Context -> _)
-  	raise Kemal::Exceptions::InvalidPathStartException.new({{method}}, path) unless Kemal::Utils.path_starts_with_backslash?(path)
+  	raise Kemal::Exceptions::InvalidPathStartException.new({{method}}, path) unless Kemal::Utils.path_starts_with_slash?(path)
     Kemal::RouteHandler::INSTANCE.add_route({{method}}.upcase, path, &block)
   end
 {% end %}
 
 def ws(path, &block : HTTP::WebSocket, HTTP::Server::Context -> Void)
-  raise Kemal::Exceptions::InvalidPathStartException.new("ws", path) unless Kemal::Utils.path_starts_with_backslash?(path)
+  raise Kemal::Exceptions::InvalidPathStartException.new("ws", path) unless Kemal::Utils.path_starts_with_slash?(path)
   Kemal::WebSocketHandler.new path, &block
 end
 

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -9,7 +9,7 @@ FILTER_METHODS = %w(get post put patch delete options all)
 
 {% for method in HTTP_METHODS %}
   def {{method.id}}(path, &block : HTTP::Server::Context -> _)
-  	raise Kemal::Exceptions::InvalidPathStartException.new({{method}}, path) unless Kemal::Utils.path_starts_with_slash?(path)
+    raise Kemal::Exceptions::InvalidPathStartException.new({{method}}, path) unless Kemal::Utils.path_starts_with_slash?(path)
     Kemal::RouteHandler::INSTANCE.add_route({{method}}.upcase, path, &block)
   end
 {% end %}

--- a/src/kemal/helpers/utils.cr
+++ b/src/kemal/helpers/utils.cr
@@ -1,6 +1,6 @@
 module Kemal
   module Utils
-    def self.path_starts_with_backslash?(path)
+    def self.path_starts_with_slash?(path)
       path.starts_with?("/")
     end
 


### PR DESCRIPTION
This PR changes the name of `Kemal::Utils::path_starts_with_backslash` to `Kemal::Utils::path_starts_with_slash` for technical correctness reasons.

See also:
https://en.wikipedia.org/wiki/Slash_(punctuation)
https://en.wikipedia.org/wiki/Backslash