### PR TITLE
Remove extraneous newline characters passed to log helper

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -10,7 +10,7 @@ module Kemal
   # Overload of self.run with the default startup logging
   def self.run(port = nil)
     self.run port do
-      log "[#{config.env}] Kemal is ready to lead at #{config.scheme}://#{config.host_binding}:#{config.port}\n"
+      log "[#{config.env}] Kemal is ready to lead at #{config.scheme}://#{config.host_binding}:#{config.port}"
     end
   end
 
@@ -42,7 +42,7 @@ module Kemal
     # Test environment doesn't need to have signal trap, built-in images, and logging.
     unless config.env == "test"
       Signal::INT.trap {
-        log "Kemal is going to take a rest!\n" if config.shutdown_message
+        log "Kemal is going to take a rest!" if config.shutdown_message
         Kemal.stop
         exit
       }

--- a/src/kemal/common_exception_handler.cr
+++ b/src/kemal/common_exception_handler.cr
@@ -12,7 +12,7 @@ module Kemal
       rescue ex : Kemal::Exceptions::CustomException
         call_exception_with_status_code(context, ex, context.response.status_code)
       rescue ex : Exception
-        log("Exception: #{ex.inspect_with_backtrace}\n")
+        log("Exception: #{ex.inspect_with_backtrace}")
         return call_exception_with_status_code(context, ex, 500) if Kemal.config.error_handlers.has_key?(500)
         verbosity = Kemal.config.env == "production" ? false : true
         return render_500(context, ex.inspect_with_backtrace, verbosity)


### PR DESCRIPTION
This PR fixes regression introduced in 1afb4cbfa8218ab8616c59a041dcc85fa72834a8, where `log` helper came into the being.