### PR TITLE
Skip files with empty #size in ParamParser

### DIFF
--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -67,7 +67,7 @@ module Kemal
 
     private def parse_file_upload
       HTTP::FormData.parse(@request) do |upload|
-        next unless upload
+        next unless upload && upload.size
         filename = upload.filename
         if !filename.nil?
           @files[upload.name] = FileUpload.new(upload: upload)


### PR DESCRIPTION
This PR makes sure that every file returned by `ParamParser` will have its `#size` set.
Fixes #309.