### PR TITLE
User defined context store types

### DIFF
--- a/spec/context_spec.cr
+++ b/spec/context_spec.cr
@@ -34,8 +34,13 @@ describe "Context" do
 
   it "can store variables" do
     before_get "/" do |env|
+      t = TestContextStorageType.new
+      t.id = 32
+      a = AnotherContextStorageType.new
       env.set "before_get", "Kemal"
       env.set "before_get_int", 123
+      env.set "before_get_context_test", t
+      env.set "another_context_test", a
       env.set "before_get_float", 3.5
     end
 
@@ -46,6 +51,7 @@ describe "Context" do
         before_get:       env.get("before_get"),
         before_get_int:   env.get("before_get_int"),
         before_get_float: env.get("before_get_float"),
+        before_get_context_test: env.get("before_get_context_test"),
       }
     end
     request = HTTP::Request.new("GET", "/")
@@ -58,5 +64,6 @@ describe "Context" do
     context.store["before_get"].should eq "Kemal"
     context.store["before_get_int"].should eq 123
     context.store["before_get_float"].should eq 3.5
+    context.store["before_get_context_test"].as(TestContextStorageType).id.should eq 32
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -26,8 +26,8 @@ class AnotherContextStorageType
   @name = "kemal-context"
 end
 
-{{ HTTP::Server::Context::STORE_MAPPINGS << TestContextStorageType }}
-{{ HTTP::Server::Context::STORE_MAPPINGS << AnotherContextStorageType }}
+HTTP::Server::Context.add_store_type(TestContextStorageType)
+HTTP::Server::Context.add_store_type(AnotherContextStorageType)
 
 
 def create_request_and_return_io(handler, request)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -26,8 +26,8 @@ class AnotherContextStorageType
   @name = "kemal-context"
 end
 
-Kemal.add_context_storage_type(TestContextStorageType)
-Kemal.add_context_storage_type(AnotherContextStorageType)
+add_context_storage_type(TestContextStorageType)
+add_context_storage_type(AnotherContextStorageType)
 
 def create_request_and_return_io(handler, request)
   io = IO::Memory.new

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -12,6 +12,24 @@ class CustomLogHandler < Kemal::BaseLogHandler
   end
 end
 
+class TestContextStorageType
+  property id
+  @id = 1
+
+  def to_s
+    @id
+  end
+end
+
+class AnotherContextStorageType
+  property name
+  @name = "kemal-context"
+end
+
+{{ HTTP::Server::Context::STORE_MAPPINGS << TestContextStorageType }}
+{{ HTTP::Server::Context::STORE_MAPPINGS << AnotherContextStorageType }}
+
+
 def create_request_and_return_io(handler, request)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -26,9 +26,8 @@ class AnotherContextStorageType
   @name = "kemal-context"
 end
 
-HTTP::Server::Context.add_store_type(TestContextStorageType)
-HTTP::Server::Context.add_store_type(AnotherContextStorageType)
-
+Kemal.add_context_storage_type(TestContextStorageType)
+Kemal.add_context_storage_type(AnotherContextStorageType)
 
 def create_request_and_return_io(handler, request)
   io = IO::Memory.new

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -7,10 +7,6 @@ class HTTP::Server
     # :nodoc:
     STORE_MAPPINGS = [ Nil, String, Int32, Int64, Float64, Bool ]
 
-    macro add_store_type(type)
-      {{ STORE_MAPPINGS.push(type) }}
-    end
-
     macro finished
       alias StoreTypes = Union({{ *STORE_MAPPINGS }})
       getter store = {} of String => StoreTypes
@@ -45,5 +41,11 @@ class HTTP::Server
     def set(name, value)
       @store[name] = value
     end
+  end
+end
+
+module Kemal
+  macro add_context_storage_type(type)
+    {{ HTTP::Server::Context::STORE_MAPPINGS.push(type) }}
   end
 end

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -8,7 +8,7 @@ class HTTP::Server
     STORE_MAPPINGS = [ Nil, String, Int32, Int64, Float64, Bool ]
 
     macro add_store_type(type)
-      STORE_MAPPINGS << {{ type }}
+      {{ STORE_MAPPINGS.push(type) }}
     end
 
     macro finished

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -7,6 +7,10 @@ class HTTP::Server
     # :nodoc:
     STORE_MAPPINGS = [ Nil, String, Int32, Int64, Float64, Bool ]
 
+    macro add_store_type(type)
+      STORE_MAPPINGS << {{ type }}
+    end
+
     macro finished
       alias StoreTypes = Union({{ *STORE_MAPPINGS }})
       getter store = {} of String => StoreTypes

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -4,8 +4,13 @@
 # Instances of this class are passed to an `HTTP::Server` handler.
 class HTTP::Server
   class Context
-    alias StoreTypes = Nil | String | Int32 | Int64 | Float64 | Bool
-    getter store = {} of String => StoreTypes
+    # :nodoc:
+    STORE_MAPPINGS = [ Nil, String, Int32, Int64, Float64, Bool ]
+
+    macro finished
+      alias StoreTypes = Union({{ *STORE_MAPPINGS }})
+      getter store = {} of String => StoreTypes
+    end
 
     def params
       @request.url_params ||= route_lookup.params

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -43,9 +43,3 @@ class HTTP::Server
     end
   end
 end
-
-module Kemal
-  macro add_context_storage_type(type)
-    {{ HTTP::Server::Context::STORE_MAPPINGS.push(type) }}
-  end
-end

--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -76,3 +76,15 @@ macro halt(env, status_code = 200, response = "")
   {{env}}.response.close
   next
 end
+
+# Extends context storage with user defined types.
+#
+# class User
+#   property name
+# end
+#
+# add_context_storage_type(User)
+#
+macro add_context_storage_type(type)
+  {{ HTTP::Server::Context::STORE_MAPPINGS.push(type) }}
+end

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -67,7 +67,7 @@ module Kemal
 
     private def parse_file_upload
       HTTP::FormData.parse(@request) do |upload|
-        next unless upload && upload.size
+        next unless upload
         filename = upload.filename
         if !filename.nil?
           @files[upload.name] = FileUpload.new(upload: upload)


### PR DESCRIPTION
Here's my use case. The problem I'm having is that in middleware, filters or between methods, I want to store an object and not necessarily a base type. When I want an object, I end up polluting the `HTTP::Server::Context` class. I'd much prefer to be able to store the object in context storage. 

Here's a contrived example:

```crystal
require "kemal"

class MyType
  property name
  @name = "kemal"
end

HTTP::Server::Context.add_store_type(MyType)

before_get "/" do |env|
  t = MyType.new
  t.name = "awesome"
  env.set "my_type", t
end

get "/" do |env|
  t = env.get("my_type").as(MyType)
  t.name
end
```