### PR TITLE
Prevent send_file returning filesize

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -88,7 +88,7 @@ describe "Macros" do
       response = call_request_on_app(request)
       response.status_code.should eq(200)
       response.headers["Content-Type"].should eq("application/octet-stream")
-      response.headers["Content-Length"].should eq("20")
+      response.headers["Content-Length"].should eq("18")
     end
 
     it "sends file with given path and given mime-type" do
@@ -100,7 +100,7 @@ describe "Macros" do
       response = call_request_on_app(request)
       response.status_code.should eq(200)
       response.headers["Content-Type"].should eq("image/jpeg")
-      response.headers["Content-Length"].should eq("20")
+      response.headers["Content-Length"].should eq("18")
     end
 
     it "sends file with binary stream" do

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -116,6 +116,7 @@ def send_file(env, path : String, mime_type : String? = nil)
       IO.copy(file, env.response)
     end
   end
+  return
 end
 
 private def multipart(file, env)


### PR DESCRIPTION
send_file was returning file size, if you use it as the last command in a route, it would append file size to the end of the output.
not sure about other send_file, haven't tried.