### PR TITLE
Unify params

### DIFF
--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -12,7 +12,7 @@ describe "Kemal::RouteHandler" do
 
   it "routes request with query string" do
     get "/" do |env|
-      "hello #{env.params.query["message"]}"
+      "hello #{env.params["message"]}"
     end
     request = HTTP::Request.new("GET", "/?message=world")
     client_response = call_request_on_app(request)
@@ -21,7 +21,7 @@ describe "Kemal::RouteHandler" do
 
   it "routes request with multiple query strings" do
     get "/" do |env|
-      "hello #{env.params.query["message"]} time #{env.params.query["time"]}"
+      "hello #{env.params["message"]} time #{env.params["time"]}"
     end
     request = HTTP::Request.new("GET", "/?message=world&time=now")
     client_response = call_request_on_app(request)
@@ -30,7 +30,7 @@ describe "Kemal::RouteHandler" do
 
   it "route parameter has more precedence than query string arguments" do
     get "/:message" do |env|
-      "hello #{env.params.url["message"]}"
+      "hello #{env.params["message"]}"
     end
     request = HTTP::Request.new("GET", "/world?message=coco")
     client_response = call_request_on_app(request)
@@ -39,8 +39,8 @@ describe "Kemal::RouteHandler" do
 
   it "parses simple JSON body" do
     post "/" do |env|
-      name = env.params.json["name"]
-      age = env.params.json["age"]
+      name = env.params["name"]
+      age = env.params["age"]
       "Hello #{name} Age #{age}"
     end
 
@@ -57,7 +57,7 @@ describe "Kemal::RouteHandler" do
 
   it "parses JSON with string array" do
     post "/" do |env|
-      skills = env.params.json["skills"].as(Array)
+      skills = env.params["skills"].as(Array)
       "Skills #{skills.each.join(',')}"
     end
 
@@ -74,7 +74,7 @@ describe "Kemal::RouteHandler" do
 
   it "parses JSON with json object array" do
     post "/" do |env|
-      skills = env.params.json["skills"].as(Array)
+      skills = env.params["skills"].as(Array)
       skills_from_languages = skills.map do |skill|
         skill = skill.as(Hash)
         skill["language"]

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -7,7 +7,7 @@ end
 describe "Views" do
   it "renders file" do
     get "/view/:name" do |env|
-      name = env.params.url["name"]
+      name = env.params["name"]
       render "spec/asset/hello.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
@@ -17,7 +17,7 @@ describe "Views" do
 
   it "renders file with dynamic variables" do
     get "/view/:name" do |env|
-      name = env.params.url["name"]
+      name = env.params["name"]
       render_with_base_and_layout "hello.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
@@ -27,7 +27,7 @@ describe "Views" do
 
   it "renders layout" do
     get "/view/:name" do |env|
-      name = env.params.url["name"]
+      name = env.params["name"]
       render "spec/asset/hello.ecr", "spec/asset/layout.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
@@ -37,7 +37,7 @@ describe "Views" do
 
   it "renders layout with variables" do
     get "/view/:name" do |env|
-      name = env.params.url["name"]
+      name = env.params["name"]
       var1 = "serdar"
       var2 = "kemal"
       render "spec/asset/hello_with_content_for.ecr", "spec/asset/layout_with_yield_and_vars.ecr"
@@ -51,7 +51,7 @@ describe "Views" do
 
   it "renders layout with content_for" do
     get "/view/:name" do |env|
-      name = env.params.url["name"]
+      name = env.params["name"]
       render "spec/asset/hello_with_content_for.ecr", "spec/asset/layout_with_yield.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -49,7 +49,7 @@ module Kemal
 
       # This route serves the built-in images for not_found and exceptions.
       get "/__kemal__/:image" do |env|
-        image = env.params.url["image"]
+        image = env.params["image"]
         file_path = File.expand_path("lib/kemal/images/#{image}", Dir.current)
         if File.exists? file_path
           send_file env, file_path

--- a/src/kemal/ext/request.cr
+++ b/src/kemal/ext/request.cr
@@ -18,11 +18,11 @@ class HTTP::Request
   private def check_for_method_override!
     @override_method = @method
     if @method == "POST"
-      @param_parser = Kemal::ParamParser.new(self)
-      params = @param_parser.not_nil!.body
-      if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
-        @override_method = params["_method"]
-      end
+      # @param_parser = Kemal::ParamParser.new(self)
+      # params = @param_parser.not_nil!.body
+      # if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
+      #   @override_method = params["_method"]
+      # end
     end
     @override_method
   end

--- a/src/kemal/ext/request.cr
+++ b/src/kemal/ext/request.cr
@@ -18,11 +18,8 @@ class HTTP::Request
   private def check_for_method_override!
     @override_method = @method
     if @method == "POST"
-      # @param_parser = Kemal::ParamParser.new(self)
-      # params = @param_parser.not_nil!.body
-      # if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
-      #   @override_method = params["_method"]
-      # end
+      params = HTTP::Params.parse(self.body.to_s)
+      @override_method = params["_method"] if params.has_key?("_method")
     end
     @override_method
   end

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -8,8 +8,7 @@ module Kemal
     MULTIPART_FORM   = "multipart/form-data"
     # :nodoc:
     alias AllParamTypes = Nil | String | Int64 | Float64 | Bool | Hash(String, JSON::Type) | Array(JSON::Type)
-    getter params
-    getter files
+    getter params, files
 
     def initialize(@request : HTTP::Request)
       @params = {} of String => AllParamTypes

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -13,6 +13,7 @@ module Kemal
     def initialize(@request : HTTP::Request)
       @params = {} of String => AllParamTypes
       @files = {} of String => FileUpload
+      @params_parsed = false
     end
 
     private def unescape_url_param(value : String)
@@ -22,10 +23,12 @@ module Kemal
     end
 
     def parse
+      return if @params_parsed
       parse_url
       parse_query
       parse_body
       parse_json
+      @params_parsed = true
     end
 
     private def parse_body

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -44,7 +44,7 @@ module Kemal
     end
 
     private def remove_tmpfiles(context)
-      context.params.files.each do |field, file|
+      context.files.each do |field, file|
         File.delete(file.tmpfile.path) if ::File.exists?(file.tmpfile.path)
       end
     end


### PR DESCRIPTION
This unifies accessing `HTTP::Server::Context` params.

Before

```crystal
env.params.url["url_param"]
env.params.query["query_param"]
env.params.body["body_param"]
env.params.json["json_param"]
```

After

Before

```crystal
env.params["url_param"]
env.params["query_param"]
env.params["body_param"]
env.params["json_param"]
```