### PR TITLE
X-Content-Type-Options = "nosniff" #379

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -98,6 +98,7 @@ def send_file(env, path : String, mime_type : String? = nil)
   file_path = File.expand_path(path, Dir.current)
   mime_type ||= Kemal::Utils.mime_type(file_path)
   env.response.content_type = mime_type
+  env.response.headers["X-Content-Type-Options"] = "nosniff"
   minsize = 860 # http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits ??
   request_headers = env.request.headers
   filesize = File.size(file_path)


### PR DESCRIPTION
security header for older browsers to prevent content sniffing