### PR TITLE
allow %w in Handler macros

### DIFF
--- a/spec/handler_spec.cr
+++ b/spec/handler_spec.cr
@@ -47,6 +47,26 @@ class PostExcludeHandler < Kemal::Handler
   end
 end
 
+class ExcludeHandlerPercentW < Kemal::Handler
+  exclude %w[/exclude]
+
+  def call(env)
+    return call_next(env) if exclude_match?(env)
+    env.response.print "Exclude"
+    call_next env
+  end
+end
+
+class PostOnlyHandlerPercentW < Kemal::Handler
+  only %w[/only /route1 /route2], "POST"
+
+  def call(env)
+    return call_next(env) unless only_match?(env)
+    env.response.print "Only"
+    call_next env
+  end
+end
+
 describe "Handler" do
   it "adds custom handler before before_*" do
     filter_middleware = Kemal::FilterHandler.new
@@ -130,5 +150,12 @@ describe "Handler" do
     post_exclude_handler = PostExcludeHandler.new
     Kemal.config.handlers = [post_only_handler, post_exclude_handler]
     Kemal.config.handlers.should eq [post_only_handler, post_exclude_handler]
+  end
+
+  it "is able to use %w in macros" do
+    post_only_handler = PostOnlyHandlerPercentW.new
+    exclude_handler = ExcludeHandlerPercentW.new
+    Kemal.config.handlers = [post_only_handler, exclude_handler]
+    Kemal.config.handlers.should eq [post_only_handler, exclude_handler]
   end
 end

--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -9,14 +9,14 @@ module Kemal
 
     macro only(paths, method = "GET")
     class_name = {{@type.name}}
-    {{paths}}.each do |path|
+    ({{paths}}).each do |path|
       @@only_routes_tree.add "#{class_name}/#{{{method}}.downcase}#{path}", "/#{{{method}}.downcase}#{path}"
     end
   end
 
     macro exclude(paths, method = "GET")
     class_name = {{@type.name}}
-    {{paths}}.each do |path|
+    ({{paths}}).each do |path|
       @@exclude_routes_tree.add "#{class_name}/#{{{method}}.downcase}#{path}", "/#{{{method}}.downcase}#{path}"
     end
   end


### PR DESCRIPTION
Without parens, the macro is expanded to 
```
   2.     ["/one", "/two"] of ::String.each do |path|
   3.       @@exclude_routes_tree.add "#{class_name}/#{"GET".downcase}#{path}", "/#{"GET".downcase}#{path}"
   4.     end
   5.
```

which is a syntax error