### PR TITLE
Allow headers in built-in static file server

### DIFF
--- a/spec/static/dir/index.html
+++ b/spec/static/dir/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>title</title>
+    <link rel="stylesheet" href="style.css">
+    <script src="script.js"></script>
+  </head>
+  <body>
+    <!-- page content -->
+  </body>
+</html>

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -21,6 +21,7 @@ module Kemal
       always_rescue, serve_static : (Bool | Hash(String, Bool)), server, extra_options,
       shutdown_message
     getter custom_handler_position
+    property static_headers : (HTTP::Server::Response, String, File::Stat -> Void)?
 
     def initialize
       @host_binding = "0.0.0.0"

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -102,6 +102,10 @@ def send_file(env, path : String, mime_type : String? = nil)
   minsize = 860 # http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits ??
   request_headers = env.request.headers
   filesize = File.size(file_path)
+  filestat = File.stat(file_path)
+
+  Kemal.config.static_headers.try(&.call(env.response, file_path, filestat))
+
   File.open(file_path) do |file|
     if env.request.method == "GET" && env.request.headers.has_key?("Range")
       next multipart(file, env)
@@ -195,4 +199,8 @@ end
 # It's disabled by default.
 def gzip(status : Bool = false)
   add_handler HTTP::CompressHandler.new if status
+end
+
+def static_headers(&headers : HTTP::Server::Response, String, File::Stat -> Void)
+  Kemal.config.static_headers = headers
 end


### PR DESCRIPTION
This PR adds support for customizing the headers of built-in `Kemal::StaticFileHandler`. Useful for supporting `CORS` 👍 

```crystal
static_headers do |response, filepath, filestat|
    if filepath =~ /\.html$/
        response.headers.add("Access-Control-Allow-Origin", "*")
      end
      response.headers.add("Content-Size", filestat.size.to_s)
    end
end
```

Based on #228, fixes https://github.com/kemalcr/kemal/issues/233