### PR TITLE
Set correct namespace for Route

### DIFF
--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -33,7 +33,7 @@ class HTTP::Server
     end
 
     def route
-      route_lookup.payload.as(Route)
+      route_lookup.payload.as(Kemal::Route)
     end
 
     def route_lookup


### PR DESCRIPTION
Fixes compile error "undefined constant Route"