### PR TITLE
WIP: Add get, get?, all methods to Kemal::ParamParser

### DIFF
--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -21,6 +21,38 @@ module Kemal
       @body_parsed = false
       @json_parsed = false
     end
+    
+    # Checks each of the different parameter stores in turn for the given
+    # parameter name, and returns it if found
+    def get?(name : String) : AllParamTypes
+      {% for method in %w(json body query url) %}
+        return @{{method.id}}[name] if @{{method.id}}.has_key? name
+      {% end %}
+    end
+
+    # Checks each of the different parameter stores in turn for the given
+    # parameter name, and returns it if found. Otherwise, returns the default
+    def get(name : String, default : AllParamTypes = nil) : AllParamTypes
+      if value = get?(name)
+        return value
+      end
+
+      default
+    end
+
+    # Returns a hash containing parameters from all stores
+    def all : Hash(String, AllParamTypes)
+      params = {} of String => AllParamTypes
+
+      {% for method in %w(url query body json) %}
+        puts "{{method.id}}", @{{method.id}}
+        {{method.id}}.each do |key, value|
+          params[key] = value
+        end
+      {% end %}
+
+      params
+    end
 
     private def unescape_url_param(value : String)
       value.size == 0 ? value : URI.unescape(value)


### PR DESCRIPTION
I appreciate this may be a controversial proposal, hence why I've submitted it as WIP.

Taking inspiration from other frameworks, it would be handy if it was possible to retrieve request parameters from any/all available sources (url, query, json and body) without having to add method/content-type checking boilerplate for every call.

This PR adds three methods to `Kemal::ParamParser`: `get`, `get?` and `all`, which make it much easier to retrieve values, as well as specifying a fallback in the case of `get`. An example:

```crystal
# Given a request to /test/molovo?v=2
get "/test/:name" do |env|
  # Returns value or nil
  name = env.params.get?("name").as(String)
  # => molovo

  # Returns value or default
  page = env.params.get("page", 1).as(Int32)
  # => 1

  data = env.params.all
  # => {
         "name" => "molovo",
         "v"    => 2
       }
end
```

There is obviously a slight compromise in terms of performance, but given the number of request parameters in the average HTTP request, this is likely to be minimal. Even so, if it is clearly documented, then those looking for optimal performance can still continue to use the previous methods, which haven't been changed.

I haven't written tests yet, since I wanted to see if this was something the community was interested in first before putting too much time into it, and to get some feedback on the order in which parameters are retrieved. If the consensus is yes, then I'll get the tests written so that this can be pushed through. Your thoughts, please!