### PR TITLE
Fix for video in safari

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -152,9 +152,10 @@ private def multipart(file, env : HTTP::Server::Context)
     endb = fileb - 1
   end
 
-  if startb < endb && endb <= fileb
+  if startb < endb && endb < fileb
+    content_length = 1 + endb - startb
     env.response.status_code = 206
-    env.response.content_length = endb - startb
+    env.response.content_length = content_length
     env.response.headers["Accept-Ranges"] = "bytes"
     env.response.headers["Content-Range"] = "bytes #{startb}-#{endb}/#{fileb}" # MUST
 
@@ -172,7 +173,7 @@ private def multipart(file, env : HTTP::Server::Context)
       file.skip(startb)
     end
 
-    IO.copy(file, env.response, endb - startb)
+    IO.copy(file, env.response, content_length)
   else
     env.response.content_length = fileb
     env.response.status_code = 200 # Range not satisfable, see 4.4 Note

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -149,14 +149,14 @@ private def multipart(file, env : HTTP::Server::Context)
   end
 
   if endb == 0
-    endb = fileb
+    endb = fileb - 1
   end
 
   if startb < endb && endb <= fileb
     env.response.status_code = 206
     env.response.content_length = endb - startb
     env.response.headers["Accept-Ranges"] = "bytes"
-    env.response.headers["Content-Range"] = "bytes #{startb}-#{endb > 1 ? endb - 1 : 1}/#{fileb}" # MUST
+    env.response.headers["Content-Range"] = "bytes #{startb}-#{endb}/#{fileb}" # MUST
 
     if startb > 1024
       skipped = 0

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -156,7 +156,7 @@ private def multipart(file, env : HTTP::Server::Context)
     env.response.status_code = 206
     env.response.content_length = endb - startb
     env.response.headers["Accept-Ranges"] = "bytes"
-    env.response.headers["Content-Range"] = "bytes #{startb}-#{endb - 1}/#{fileb}" # MUST
+    env.response.headers["Content-Range"] = "bytes #{startb}-#{endb > 1 ? endb - 1 : 1}/#{fileb}" # MUST
 
     if startb > 1024
       skipped = 0

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -98,6 +98,7 @@ def send_file(env : HTTP::Server::Context, path : String, mime_type : String? = 
   file_path = File.expand_path(path, Dir.current)
   mime_type ||= Kemal::Utils.mime_type(file_path)
   env.response.content_type = mime_type
+  env.response.headers["Accept-Ranges"] = "bytes"
   env.response.headers["X-Content-Type-Options"] = "nosniff"
   minsize = 860 # http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits ??
   request_headers = env.request.headers


### PR DESCRIPTION
Video doesn't work in safari.

It seem to be to do with the content-range header. Safari initially asked for the first byte. 
However with a single byte request, the header outputs
`bytes 0-0/1000` (if this file is 1000 bytes in size)

It does work however if we make the end value 1. But removing the `-1` it breaks it in chrome. So I suggest this change, which means the end can't be smaller than 1.