### PR TITLE
Serve index.html when GET / route is missing

### DIFF
--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -100,13 +100,13 @@ module Kemal
         setup_init_handler
         setup_log_handler
         setup_error_handler
-        setup_static_file_handler
         setup_custom_handlers
         setup_filter_handlers
         @default_handlers_setup = true
         @router_included = true
         HANDLERS.insert(HANDLERS.size, Kemal::WebSocketHandler::INSTANCE)
         HANDLERS.insert(HANDLERS.size, Kemal::RouteHandler::INSTANCE)
+        setup_static_file_handler
       end
     end
 
@@ -135,8 +135,8 @@ module Kemal
 
     private def setup_static_file_handler
       if @serve_static.is_a?(Hash)
-        HANDLERS.insert(@handler_position, Kemal::StaticFileHandler.new(@public_folder))
         @handler_position += 1
+        HANDLERS.insert(@handler_position, Kemal::StaticFileHandler.new(@public_folder))
       end
     end
 

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -5,7 +5,7 @@
 module Kemal
   class StaticFileHandler < HTTP::StaticFileHandler
     def call(context : HTTP::Server::Context)
-      return call_next(context) if context.request.path.not_nil! == "/"
+      # return call_next(context) if context.request.path.not_nil! == "/"
 
       unless context.request.method == "GET" || context.request.method == "HEAD"
         if @fallthrough
@@ -38,7 +38,12 @@ module Kemal
       file_path = File.join(@public_dir, expanded_path)
       is_dir = Dir.exists? file_path
 
-      if request_path != expanded_path || is_dir && !is_dir_path
+      is_root_path = expanded_path == "/"
+      if is_root_path 
+        file_path = File.join(@public_dir, "/index.html")
+      end
+
+      if request_path != expanded_path || is_dir && !is_dir_path && !is_root_path
         redirect_to context, "#{expanded_path}#{is_dir && !is_dir_path ? "/" : ""}"
       end
 


### PR DESCRIPTION
### Description of the Change

I started developing my application using Kemal and i was disappointed when i created /public folder and index.html file inside, and Kemal doesn't send it to me. I think it should be default behavior if 
`get "/" do`
is missing. But in case of index.html AND specified handler for root path (get "/" do), it should execute handler.

### Alternate Designs

Any suggestions are welcome

### Benefits

Now you don't need specify send_file("index.html") if you want just to send index.html file by default

### Possible Drawbacks

none i guess
