### PR TITLE
Add in type options to URL parameters

### DIFF
--- a/spec/url_typed_param_handler_spec.cr
+++ b/spec/url_typed_param_handler_spec.cr
@@ -1,0 +1,45 @@
+require "./spec_helper"
+
+describe "UrlTypedParamHandler" do
+  describe "#cast_as" do
+    context "boolean values" do
+      it "handles truthy values" do
+        test1 = Kemal::UrlTypedParamHandler.cast_as(Bool, "true")
+        test2 = Kemal::UrlTypedParamHandler.cast_as(Bool, "hey there")
+
+        test1.should eq(true)
+        test2.should eq(true)
+      end
+
+      it "handles falsey values" do
+        test1 = Kemal::UrlTypedParamHandler.cast_as(Bool, "false")
+        test2 = Kemal::UrlTypedParamHandler.cast_as(Bool, "f")
+
+        test1.should eq(false)
+        test2.should eq(false)
+      end
+    end
+
+    context "integer values" do
+      it "handles Int32 values" do
+        test = Kemal::UrlTypedParamHandler.cast_as(Int32, "42")
+
+        test.should eq(42)
+      end
+    end
+
+    context "string values" do
+      it "handles escaped values" do
+        test = Kemal::UrlTypedParamHandler.cast_as(String, "lollar%2Bspec%40gmail.com")
+
+        test.should eq("lollar+spec@gmail.com")
+      end
+
+      it "handles unescaped values" do
+        test = Kemal::UrlTypedParamHandler.cast_as(String, "codalus")
+
+        test.should eq("codalus")
+      end
+    end
+  end
+end

--- a/spec/url_typed_param_handler_spec.cr
+++ b/spec/url_typed_param_handler_spec.cr
@@ -21,8 +21,8 @@ describe "UrlTypedParamHandler" do
     end
 
     context "integer values" do
-      it "handles Int32 values" do
-        test = Kemal::UrlTypedParamHandler.cast_as(Int32, "42")
+      it "handles Int64 values" do
+        test = Kemal::UrlTypedParamHandler.cast_as(Int64, "42")
 
         test.should eq(42)
       end
@@ -39,6 +39,14 @@ describe "UrlTypedParamHandler" do
         test = Kemal::UrlTypedParamHandler.cast_as(String, "codalus")
 
         test.should eq("codalus")
+      end
+    end
+
+    context "float values" do
+      it "returns Float64 value" do
+        test = Kemal::UrlTypedParamHandler.cast_as(Float64, "0.42")
+
+        test.should eq(0.42)
       end
     end
   end

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -7,15 +7,16 @@ module Kemal
     APPLICATION_JSON = "application/json"
     MULTIPART_FORM   = "multipart/form-data"
     PARTS = %w(url query body json)
-    PERMITTED_URL_TYPES = { 
-      "int" => Int32,
+    PERMITTED_URL_PARAM_TYPES = { 
+      "int" => Int64,
       "string" => String,
-      "boolean" => Bool
+      "boolean" => Bool,
+      "float" => Float64
     }
 
     # :nodoc:
     alias AllParamTypes = Nil | String | Int64 | Float64 | Bool | Hash(String, JSON::Type) | Array(JSON::Type)
-    alias AllUrlParamTypes = Int32 | String | Bool
+    alias AllUrlParamTypes = Int64 | String | Bool | Float64 
     getter files
 
     def initialize(@request : HTTP::Request)
@@ -71,9 +72,9 @@ module Kemal
           type = (/\[.*\]/).match(key).try &.[0]
           type = type.gsub(/[^a-z0-9]/i, "") unless type.nil?
 
-          if PERMITTED_URL_TYPES.keys.includes?(type)
+          if PERMITTED_URL_PARAM_TYPES.keys.includes?(type)
             parsed_key = key.gsub("[#{type}]", "")
-            @url[parsed_key] = UrlTypedParamHandler.cast_as(PERMITTED_URL_TYPES[type], value)
+            @url[parsed_key] = UrlTypedParamHandler.cast_as(PERMITTED_URL_PARAM_TYPES[type], value)
           else
             @url[key] = unescape_url_param(value)
           end

--- a/src/kemal/url_typed_param_handler.cr
+++ b/src/kemal/url_typed_param_handler.cr
@@ -1,0 +1,18 @@
+module Kemal
+  # Casts the typed parameters passed in via the URL
+  class UrlTypedParamHandler
+    FALSEY_VALUES = ["false", "f"]
+
+    def self.cast_as(type : Int32.class, value : String)
+      type.new(value)
+    end
+
+    def self.cast_as(type : Bool.class, value : String)
+      !FALSEY_VALUES.includes?(value)
+    end
+
+    def self.cast_as(type : String.class, value : String)
+      value.size == 0 ? value : URI.unescape(value) rescue value
+    end
+  end
+end

--- a/src/kemal/url_typed_param_handler.cr
+++ b/src/kemal/url_typed_param_handler.cr
@@ -3,16 +3,20 @@ module Kemal
   class UrlTypedParamHandler
     FALSEY_VALUES = ["false", "f"]
 
-    def self.cast_as(type : Int32.class, value : String)
+    def self.cast_as(type : Int64.class, value : String) : Int64
       type.new(value)
     end
 
-    def self.cast_as(type : Bool.class, value : String)
+    def self.cast_as(type : Bool.class, value : String) : Bool
       !FALSEY_VALUES.includes?(value)
     end
 
-    def self.cast_as(type : String.class, value : String)
+    def self.cast_as(type : String.class, value : String) : String
       value.size == 0 ? value : URI.unescape(value) rescue value
+    end
+
+    def self.cast_as(type : Float64.class, value : String) : Float64
+      type.new(value)
     end
   end
 end


### PR DESCRIPTION
Closes #352 

### Description of the Change
* Updates the parse_url method to handle `[type]` in url
* Creates a separate class to handle the typed url params

### Alternate Designs
* Macro implementation for types (couldn't get this to work nicely)

I considered defining types in the path like: `/hello/:id[Int32]` because you could directly correlate the type with a type defined in Crystal. Ultimately I decided to go what was discussed in the issue.

### Benefits

You will be able to have typed url parameters.

### Possible Drawbacks

I believe that I have safeguarded against any possible drawbacks. If the URL contains a key like: `/hello/:id[stuff]` then it will not blow up or cast the value but proceed like it would have previously.

One potential problem would be if a user did something like: `/hello/:id[int]` and then used the URL /hello/lollar.  In that case they would get an Invalid Int error, but that seems like expected behavior to me.
