### PR TITLE
Extract etag logic from StaticFileHandler

### DIFF
--- a/spec/helpers/etag_spec.cr
+++ b/spec/helpers/etag_spec.cr
@@ -1,0 +1,63 @@
+require "../spec_helper"
+
+describe Kemal::Etag do
+  describe ".add_header" do
+    it "adds Etag header to headers" do
+      headers = HTTP::Headers.new
+      Kemal::Etag.add_header(headers, "new-etag")
+      headers["Etag"].should eq "new-etag"
+    end
+  end
+
+  describe ".matches?" do
+    it "returns false if If-None-Match is not included" do
+      headers = HTTP::Headers.new
+      Kemal::Etag.matches?(headers, "request-etag").should be_false
+    end
+
+    it "returns false where etag differs" do
+      headers = HTTP::Headers{"If-None-Match" => "different etag"}
+      Kemal::Etag.matches?(headers, "request-etag").should be_false
+    end
+
+    it "returns true on a match" do
+      headers = HTTP::Headers{"If-None-Match" => "request-etag"}
+      Kemal::Etag.matches?(headers, "request-etag").should be_true
+    end
+  end
+
+  describe ".from_file" do
+    it "returns etag based on file's mtime" do
+      file_path = "#{__DIR__}/../static/dir/test.txt"
+      Kemal::Etag.from_file(file_path).should match(/W\/"\d+"$/)
+    end
+  end
+
+  describe ".set_not_modified" do
+    it "removes content type header" do
+      response = HTTP::Server::Response.new(IO::Memory.new)
+      response.content_type = "content-type"
+
+      response.headers["Content-Type"]?.should_not be_nil
+      Kemal::Etag.set_not_modified(response)
+      response.headers["Content-Type"]?.should be_nil
+    end
+
+    it "sets content length to 0" do
+      response = HTTP::Server::Response.new(IO::Memory.new)
+      response.content_length = 42
+
+      response.headers["Content-Length"].should eq("42")
+      Kemal::Etag.set_not_modified(response)
+      response.headers["Content-Length"].should eq("0")
+    end
+
+    it "sets status code to NotModified" do
+      response = HTTP::Server::Response.new(IO::Memory.new)
+      response.status_code = 200
+
+      Kemal::Etag.set_not_modified(response)
+      response.status_code.should eq 304
+    end
+  end
+end

--- a/src/kemal/helpers/etag.cr
+++ b/src/kemal/helpers/etag.cr
@@ -1,0 +1,21 @@
+module Kemal
+  class Etag
+    def self.add_header(headers : HTTP::Headers, etag : String) : Nil
+      headers["ETag"] = etag
+    end
+
+    def self.matches?(headers : HTTP::Headers, etag : String) : Bool
+      !!(headers["If-None-Match"]? && headers["If-None-Match"] == etag)
+    end
+
+    def self.from_file(file_path : String) : String
+      %{W/"#{File.lstat(file_path).mtime.epoch.to_s}"}
+    end
+
+    def self.set_not_modified(response : HTTP::Server::Response) : Nil
+      response.headers.delete "Content-Type"
+      response.content_length = 0
+      response.status_code = 304
+    end
+  end
+end


### PR DESCRIPTION
### Description of the Change

This decouples a little bit `Kemal::StaticFileHandler` and allows re-using `Kemal::Etag` - can be handy when you want to _etagify_ some of your responses.

### Alternate Designs

Extracting this whole etag thing into a shard might be a good idea, but in the long run. I guess at this point it's _good enough_.

### Benefits

Makes code a little bit re-usable (internally, when you're building stuff around Kemal).

### Possible Drawbacks

Developers might rely on library internals that could possibly change in the future. But again - given the fact that something like #378 is desired things _will_ change anyhow.

Overall lemme know wdyt, I just wanted to avoid copy&pasting another code snippet into my app when basically very similar code was already there, cheers 🍻 