### PR TITLE
Improve Installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ dependencies:
     github: kemalcr/kemal
 ```
 
+See also [Getting Started](http://kemalcr.com/guide/).
+
 # Features
 
 - Support all REST verbs


### PR DESCRIPTION
[Getting Started](http://kemalcr.com/guide/) in Kemal's official document is clear. Commands from installation of Crsytal-lang to application creation are not omitted. I added a link to Getting Started into Installation.