### PR TITLE
Ability to optionally disable powered-by header

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -17,6 +17,10 @@ describe "Config" do
     config.env.should eq "production"
   end
 
+  it "sets default powered_by_header to true" do
+    Kemal.config.powered_by_header.should eq true
+  end
+
   it "sets host binding" do
     config = Kemal.config
     config.host_binding = "127.0.0.1"

--- a/spec/init_handler_spec.cr
+++ b/spec/init_handler_spec.cr
@@ -19,4 +19,14 @@ describe "Kemal::InitHandler" do
     Kemal::InitHandler::INSTANCE.call(context)
     context.response.headers["X-Powered-By"].should eq "Kemal"
   end
+
+  it "does not initialize context with X-Powered-By: Kemal if disabled" do
+    Kemal.config.powered_by_header = false
+    request = HTTP::Request.new("GET", "/")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::InitHandler::INSTANCE.call(context)
+    context.response.headers["X-Powered-By"]?.should eq nil
+  end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -22,6 +22,7 @@ module Kemal
     property always_rescue, server : HTTP::Server?, extra_options, shutdown_message
     property serve_static : (Bool | Hash(String, Bool))
     property static_headers : (HTTP::Server::Response, String, File::Stat -> Void)?
+    property powered_by_header : Bool = true
 
     def initialize
       @host_binding = "0.0.0.0"

--- a/src/kemal/init_handler.cr
+++ b/src/kemal/init_handler.cr
@@ -7,7 +7,7 @@ module Kemal
     INSTANCE = new
 
     def call(context : HTTP::Server::Context)
-      context.response.headers.add "X-Powered-By", "Kemal"
+      context.response.headers.add "X-Powered-By", "Kemal" if Kemal.config.powered_by_header
       context.response.content_type = "text/html" unless context.response.headers.has_key?("Content-Type")
       call_next context
     end


### PR DESCRIPTION
### Description of the Change
This PR fixes #447 by adding a new property to the config class `powered_by_header`  This property, true by default, determines if the header `X-Powered-By: Kemal` should be included in all response headers.

#### Usage

`Kemal.config.powered_by_header = false`
