### PR TITLE
reset values to test with default value

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -2,13 +2,11 @@ require "./spec_helper"
 
 describe "Config" do
   it "sets default port to 3000" do
-    config = Kemal.config
-    config.port.should eq 3000
+    Kemal::Config.new.port.should eq 3000
   end
 
   it "sets default environment to development" do
-    config = Kemal.config
-    config.env.should eq "development"
+    Kemal::Config.new.env.should eq "development"
   end
 
   it "sets environment to production" do
@@ -18,7 +16,7 @@ describe "Config" do
   end
 
   it "sets default powered_by_header to true" do
-    Kemal.config.powered_by_header.should be_true
+    Kemal::Config.new.powered_by_header.should be_true
   end
 
   it "sets host binding" do

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -54,6 +54,7 @@ module Kemal
     end
 
     def clear
+      @powered_by_header = true
       @router_included = false
       @handler_position = 0
       @default_handlers_setup = false


### PR DESCRIPTION
PR to make `crystal spec` run with default value for the case requires it. 

On my local, `~/Workspace/kemal$ crystal spec` failed because of;

```
Failures:

  1) Config sets default powered_by_header to true
     Failure/Error: Kemal.config.powered_by_header.should be_true

       Expected: true
            got: false

     # spec/config_spec.cr:21

Finished in 7.76 milliseconds
103 examples, 1 failures, 0 errors, 0 pending

Failed examples:

crystal spec spec/config_spec.cr:20 # Config sets default powered_by_header to true
```

I found `"does not initialize context with X-Powered-By: Kemal if disabled"` in init_handler_spec.cr runs before the above test.  
And it set `Kemal.config.powered_by_header = false` in shared `Kemal::Config::INSTANCE`.  
(`Kemal::Config::INSTANCE` is constant so it will be shared if test cases access config with `Kemal.config`)  
https://github.com/kemalcr/kemal/blob/master/spec/init_handler_spec.cr#L24


Test which checks default values should use a new instance of `Kemal::Config`.  
(I also fixed same type of things in this PR even though they are passed now)

On the other hand, now many tests use shared `Config`, so `Config.powered_by_header` should be also `clear`ed in `Spec.after_each`, I think.

But, anyway, I don't know why the object is shared with many tests.  
If anyone knows the reason, please tell me.