### PR TITLE
add support for multiple worker processes

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -5,6 +5,10 @@ describe "Config" do
     Kemal::Config.new.port.should eq 3000
   end
 
+  it "sets default amount of workers to 1" do
+    Kemal::Config.new.workers.should eq 1
+  end
+
   it "sets default environment to development" do
     Kemal::Config.new.env.should eq "development"
   end

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -8,54 +8,30 @@ require "./kemal/helpers/*"
 
 module Kemal
   # Overload of `self.run` with the default startup logging.
-  def self.run(port : Int32?)
-    self.run port do
-      log "[#{config.env}] Kemal is ready to lead at #{config.scheme}://#{config.host_binding}:#{config.port}"
+  def self.run(port : Int32? = nil, workers : Int32? = nil)
+    self.run port, workers do
+      log "[#{config.env}] Kemal is ready to lead #{config.workers} worker(s) at #{config.scheme}://#{config.host_binding}:#{config.port}"
     end
-  end
-
-  # Overload of `self.run` without port.
-  def self.run
-    self.run(nil)
   end
 
   # Overload of `self.run` to allow just a block.
   def self.run(&block)
-    self.run nil, &block
+    self.run nil, nil, &block
   end
 
   # The command to run a `Kemal` application.
   #
   # If *port* is not given Kemal will use `Kemal::Config#port`
-  def self.run(port : Int32? = nil, &block)
+  def self.run(port : Int32? = nil, workers : Int32? = nil, &block)
     Kemal::CLI.new
     config = Kemal.config
     config.setup
     config.port = port if port
+    config.workers = workers if workers
 
     unless Kemal.config.error_handlers.has_key?(404)
       error 404 do
         render_404
-      end
-    end
-
-    # Test environment doesn't need to have signal trap, built-in images, and logging.
-    unless config.env == "test"
-      Signal::INT.trap do
-        log "Kemal is going to take a rest!" if config.shutdown_message
-        Kemal.stop
-        exit
-      end
-
-      # This route serves the built-in images for not_found and exceptions.
-      get "/__kemal__/404.png" do |env|
-        file_path = File.expand_path("lib/kemal/images/404.png", Dir.current)
-
-        if File.exists? file_path
-          send_file env, file_path
-        else
-          halt env, 404
-        end
       end
     end
 
@@ -68,7 +44,38 @@ module Kemal
     config.running = true
 
     yield config
-    server.listen(config.host_binding, config.port) if config.env != "test"
+
+    # Test environment doesn't need to have signal trap, built-in images, and logging.
+    return if config.env == "test"
+
+    # This route serves the built-in images for not_found and exceptions.
+    get "/__kemal__/404.png" do |env|
+      file_path = File.expand_path("lib/kemal/images/404.png", Dir.current)
+
+      if File.exists? file_path
+        send_file env, file_path
+      else
+        halt env, 404
+      end
+    end
+
+    worker_processes = config.worker_processes = config.workers.times.map do
+      Process.fork do
+        config.worker = true
+        Signal::INT.trap { Kemal.stop }
+        server.listen(config.host_binding, config.port, reuse_port: config.workers > 1)
+      end
+    end.to_a
+
+    Signal::INT.trap do
+      log "Kemal is going to take a rest!" if config.shutdown_message
+    end
+
+    worker_processes.each_with_index do |process, index|
+      pid = process.pid
+      status = process.wait
+      log "Kemal worker #{index} with pid #{process.pid} terminated with status #{status.exit_status}"
+    end
   end
 
   def self.stop

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -18,7 +18,7 @@ module Kemal
       @ssl : OpenSSL::SSL::Context::Server?
     {% end %}
 
-    property host_binding, ssl, port, env, public_folder, logging, running
+    property host_binding, ssl, port, env, public_folder, logging, running, workers, worker_processes, worker
     property always_rescue, server : HTTP::Server?, extra_options, shutdown_message
     property serve_static : (Bool | Hash(String, Bool))
     property static_headers : (HTTP::Server::Response, String, File::Info -> Void)?
@@ -39,6 +39,9 @@ module Kemal
       @running = false
       @shutdown_message = true
       @handler_position = 0
+      @workers = 1
+      @worker_processes = [] of Process
+      @worker = false
     end
 
     def logger


### PR DESCRIPTION
### Description of the Change

This allows spawning multiple worker processes to handle requests on multi-core environments. It makes use of the reuse_port option in HTTP::Server (or TCPServer).

### Benefits

Should result in way higher throughput (optimally n times higher with n being the amount of workers and cpus on a host)

### Possible Drawbacks

Higher memory consumtion since fork is used.
