### PR TITLE
Refactor `Kemal.run` to allow custom port binding

### DIFF
--- a/spec/run_spec.cr
+++ b/spec/run_spec.cr
@@ -1,20 +1,48 @@
 require "./spec_helper"
 
+private def run(code)
+  code = <<-CR
+    require "./src/kemal"
+    #{code}
+    CR
+  String.build do |stdout|
+    stderr = String.build do |stderr|
+      Process.new("crystal", ["eval"], input: IO::Memory.new(code), output: stdout, error: stderr).wait
+    end
+    unless stderr.empty?
+      fail(stderr)
+    end
+  end
+end
+
 describe "Run" do
   it "runs a code block after starting" do
-    Kemal.config.env = "test"
-    make_me_true = false
-    Kemal.run do
-      make_me_true = true
-      Kemal.stop
-    end
-    make_me_true.should eq true
+    run(<<-CR).should eq "started\nstopped\n"
+      Kemal.config.env = "test"
+      Kemal.run do
+        puts "started"
+        Kemal.stop
+        puts "stopped"
+      end
+      CR
   end
 
   it "runs without a block being specified" do
-    Kemal.config.env = "test"
-    Kemal.run
-    Kemal.config.running.should eq true
-    Kemal.stop
+    run(<<-CR).should eq "[test] Kemal is ready to lead at http://0.0.0.0:3000\ntrue\n"
+      Kemal.config.env = "test"
+      Kemal.run
+      puts Kemal.config.running
+      CR
+  end
+
+  it "allows custom HTTP::Server bind" do
+    run(<<-CR).should eq "[test] Kemal is ready to lead at http://127.0.0.1:3000, http://0.0.0.0:3001\n"
+      Kemal.config.env = "test"
+      Kemal.run do |config|
+        server = config.server.not_nil!
+        server.bind_tcp "127.0.0.1", 3000, reuse_port: true
+        server.bind_tcp "0.0.0.0", 3001, reuse_port: true
+      end
+      CR
   end
 end


### PR DESCRIPTION
Fixes  #459 

This allows the config block passed to `Kemal.run` to apply custom bindings to `config.server` using the new `HTTP::Server` API from Crystal 0.25.0. `Kemal.run` will only call default `server.bind_tcp(config.host_binding, config.port)` if the server was not already bound in the config block. Multiple listen interfaces are also supported (including Unix sockets) and will show in the startup log message.

In order to properly spec the behavoiour of `Kemal.run` it needs to be compiled separately, in a new process to avoid sharing global state.