### PR TITLE
Remove _method magic param

### DIFF
--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -102,48 +102,6 @@ describe "Kemal::RouteHandler" do
     client_response.body.should eq("Skills ruby,crystal")
   end
 
-  it "checks for _method param in POST request to simulate PUT" do
-    put "/" do
-      "Hello World from PUT"
-    end
-    request = HTTP::Request.new(
-      "POST",
-      "/",
-      body: "_method=PUT",
-      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded"}
-    )
-    client_response = call_request_on_app(request)
-    client_response.body.should eq("Hello World from PUT")
-  end
-
-  it "checks for _method param in POST request to simulate PATCH" do
-    patch "/" do
-      "Hello World from PATCH"
-    end
-    request = HTTP::Request.new(
-      "POST",
-      "/",
-      body: "_method=PATCH",
-      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
-    )
-    client_response = call_request_on_app(request)
-    client_response.body.should eq("Hello World from PATCH")
-  end
-
-  it "checks for _method param in POST request to simulate DELETE" do
-    delete "/" do
-      "Hello World from DELETE"
-    end
-    request = HTTP::Request.new(
-      "POST",
-      "/",
-      body: "_method=DELETE",
-      headers: HTTP::Headers{"Content-Type" => "application/x-www-form-urlencoded; charset=UTF-8"}
-    )
-    client_response = call_request_on_app(request)
-    client_response.body.should eq("Hello World from DELETE")
-  end
-
   it "can process HTTP HEAD requests for defined GET routes" do
     get "/" do
       "Hello World from GET"

--- a/src/kemal/exceptions.cr
+++ b/src/kemal/exceptions.cr
@@ -8,7 +8,7 @@ module Kemal::Exceptions
 
   class RouteNotFound < Exception
     def initialize(context : HTTP::Server::Context)
-      super "Requested path: '#{context.request.override_method}:#{context.request.path}' was not found."
+      super "Requested path: '#{context.request.method}:#{context.request.path}' was not found."
     end
   end
 

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -15,11 +15,8 @@ class HTTP::Server
 
     def params
       @request.url_params ||= route_lookup.params
-      @params ||= if @request.param_parser
-                    @request.param_parser.not_nil!
-                  else
-                    Kemal::ParamParser.new(@request)
-                  end
+      @params ||= Kemal::ParamParser.new(@request)
+
     end
 
     def redirect(url : String, status_code : Int32 = 302)
@@ -36,7 +33,7 @@ class HTTP::Server
     end
 
     def route_lookup
-      Kemal::RouteHandler::INSTANCE.lookup_route(@request.override_method.as(String), @request.path)
+      Kemal::RouteHandler::INSTANCE.lookup_route(@request.method.as(String), @request.path)
     end
 
     def route_defined?

--- a/src/kemal/ext/request.cr
+++ b/src/kemal/ext/request.cr
@@ -1,32 +1,7 @@
 class HTTP::Request
-  property override_method
   property url_params : Hash(String, String)?
-  getter param_parser : Kemal::ParamParser?
-
-  def override_method
-    @override_method ||= check_for_method_override!
-  end
 
   def content_type
     @headers["Content-Type"]?
-  end
-
-  # Checks if method contained in _method param is valid one
-  def self.override_method_valid?(override_method : String)
-    override_method = override_method.upcase
-    override_method == "PUT" || override_method == "PATCH" || override_method == "DELETE"
-  end
-
-  # Checks if request params contain _method param to override request incoming method
-  private def check_for_method_override!
-    @override_method = @method
-    if @method == "POST"
-      @param_parser = Kemal::ParamParser.new(self)
-      params = @param_parser.not_nil!.body
-      if params.has_key?("_method") && HTTP::Request.override_method_valid?(params["_method"])
-        @override_method = params["_method"]
-      end
-    end
-    @override_method
   end
 end

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -14,12 +14,12 @@ module Kemal
     def call(context : HTTP::Server::Context)
       return call_next(context) unless context.route_defined?
       call_block_for_path_type("ALL", context.request.path, :before, context)
-      call_block_for_path_type(context.request.override_method, context.request.path, :before, context)
+      call_block_for_path_type(context.request.method, context.request.path, :before, context)
       if Kemal.config.error_handlers.has_key?(context.response.status_code)
         raise Kemal::Exceptions::CustomException.new(context)
       end
       call_next(context)
-      call_block_for_path_type(context.request.override_method, context.request.path, :after, context)
+      call_block_for_path_type(context.request.method, context.request.path, :after, context)
       call_block_for_path_type("ALL", context.request.path, :after, context)
       context
     end


### PR DESCRIPTION
### Description of the Change

Kemal had `_method` magic param to support overriding request methods. However this is not documented and not commonly used. This PR removes `_method` to be treated as a magic param.

This leads to:

- Less allocation and monkey-patching in `HTTP::Request` leading to more performance :rocket: 
- No more `env.request.body` consumption before actually accessing `env.params` :+1:  

### Alternate Designs

None

### Possible Drawbacks

- No more `_method` magic param support. 