### PR TITLE
Remove etag logic as it's not implemented in Crystal 0.25.1

### DIFF
--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -30,6 +30,7 @@ describe Kemal::StaticFileHandler do
 
     headers = HTTP::Headers{"If-None-Match" => etag}
     response = handle HTTP::Request.new("GET", "/dir/test.txt", headers)
+    response.headers["Content-Type"]?.should be_nil
     response.status_code.should eq(304)
     response.body.should eq ""
   end


### PR DESCRIPTION
### Description of the Change

Previous history: https://github.com/kemalcr/kemal/pull/440 + https://github.com/crystal-lang/crystal/pull/6145

We can now remove some code and all the tests should still pass (added one extra assertion just to be sure)

Stdlib should probably refactor whole `unless context.request.method`
block a little bit as well for more re-usability, but that's for the future

### Alternate Designs

Alternative approach in #440 was presented and rejected ;)

### Benefits

Relying on stdlib instead of duplicating own logic.

### Possible Drawbacks

Crystal 0.25.1+ as requirement - which is not something authors might want now 🤔 
