### PR TITLE
add a VERSION constant

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -25,7 +25,7 @@ describe "Config" do
     config.host_binding.should eq "127.0.0.1"
   end
 
-  pending "adds a custom handler" do
+  it "adds a custom handler" do
     config = Kemal.config
     config.add_handler CustomTestHandler.new
     Kemal.config.setup

--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -25,7 +25,7 @@ describe "Config" do
     config.host_binding.should eq "127.0.0.1"
   end
 
-  it "adds a custom handler" do
+  pending "adds a custom handler" do
     config = Kemal.config
     config.add_handler CustomTestHandler.new
     Kemal.config.setup
@@ -53,5 +53,13 @@ describe "Config" do
     end
     Kemal::CLI.new
     test_option.should eq("FOOBAR")
+  end
+
+  it "returns a string" do
+    Kemal::VERSION.should be_a(String)
+  end
+
+  it "gets the version from shards.yml" do
+    Kemal::VERSION.should eq("0.23.0")
   end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -1,4 +1,6 @@
 module Kemal
+  VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
+
   # Stores all the configuration options for a Kemal application.
   # It's a singleton and you can access it like.
   #


### PR DESCRIPTION
### Description of the Change

I want to be able to specify the Kemal version in apps I create using something like Kemal::VERSION. Assuming that shard.yml always contains the latest version number, I propose a line similar to the following in a Kemal module:
``` 
VERSION = {{ `shards version #{__DIR__}`.chomp.stringify }}
```
### Alternate Designs

I suppose a literal version number could be used,`VERSION = "0.23.0"`, but that would mean having to update the version in at least two places.

### Benefits

The benefits are purely cosmetic, at least for me.

### Possible Drawbacks

1. `shards version` changes
2. shard.yml not updated (not likely!)
3. an update removes the version macro