### PR TITLE
Remove unused require "tempfile"

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -1,7 +1,6 @@
 require "http"
 require "json"
 require "uri"
-require "tempfile"
 require "./kemal/*"
 require "./kemal/ext/*"
 require "./kemal/helpers/*"


### PR DESCRIPTION
`require "tempfile"` was left over after #465 but is not used anymore.

This PR removes it which makes Kemal compile with both Crystal 0.26.1 and current master (where `Tempfile` has been removed).