### PR TITLE
Remove deprecated alias HTTP::Server#bind_ssl

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -50,7 +50,7 @@ module Kemal
         server.bind_tcp(config.host_binding, config.port)
       {% else %}
         if ssl = config.ssl
-          server.bind_ssl(config.host_binding, config.port, ssl)
+          server.bind_tls(config.host_binding, config.port, ssl)
         else
           server.bind_tcp(config.host_binding, config.port)
         end


### PR DESCRIPTION
Closes #494

`.bind_ssl` was removed[0] from crystal-lang, use `.bind_tls` instead

- `[0]` crystal-lang/crystal#6699