### PR TITLE
Fix multipart upload

### DIFF
--- a/src/kemal/file_upload.cr
+++ b/src/kemal/file_upload.cr
@@ -1,0 +1,25 @@
+module Kemal
+  # :nodoc:
+  struct FileUpload
+    getter tmpfile : Tempfile
+    getter filename : String?
+    getter headers : HTTP::Headers
+    getter creation_time : Time?
+    getter modification_time : Time?
+    getter read_time : Time?
+    getter size : UInt64?
+
+    def initialize(upload)
+      @tmpfile = Tempfile.new(filename)
+      ::File.open(@tmpfile.path, "w") do |file|
+        IO.copy(upload.body, file)
+      end
+      @filename = upload.filename
+      @headers = upload.headers
+      @creation_time = upload.creation_time
+      @modification_time = upload.modification_time
+      @read_time = upload.read_time
+      @size = upload.size
+    end
+  end
+end

--- a/src/kemal/file_upload.cr
+++ b/src/kemal/file_upload.cr
@@ -1,5 +1,4 @@
 module Kemal
-  # :nodoc:
   struct FileUpload
     getter tempfile : File
     getter filename : String?

--- a/src/kemal/file_upload.cr
+++ b/src/kemal/file_upload.cr
@@ -1,7 +1,7 @@
 module Kemal
   # :nodoc:
   struct FileUpload
-    getter tmpfile : Tempfile
+    getter tempfile : File
     getter filename : String?
     getter headers : HTTP::Headers
     getter creation_time : Time?
@@ -10,8 +10,8 @@ module Kemal
     getter size : UInt64?
 
     def initialize(upload)
-      @tmpfile = Tempfile.new(filename)
-      ::File.open(@tmpfile.path, "w") do |file|
+      @tempfile = File.tempfile
+      ::File.open(@tempfile.path, "w") do |file|
         IO.copy(upload.body, file)
       end
       @filename = upload.filename

--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -9,11 +9,13 @@ module Kemal
     PARTS            = %w(url query body json)
     # :nodoc:
     alias AllParamTypes = Nil | String | Int64 | Float64 | Bool | Hash(String, JSON::Any) | Array(JSON::Any)
+    getter files
 
     def initialize(@request : HTTP::Request, @url : Hash(String, String) = {} of String => String)
       @query = HTTP::Params.new({} of String => Array(String))
       @body = HTTP::Params.new({} of String => Array(String))
       @json = {} of String => AllParamTypes
+      @files = [] of FileUpload
       @url_parsed = false
       @query_parsed = false
       @body_parsed = false
@@ -45,6 +47,10 @@ module Kemal
         @body = parse_part(@request.body)
         return
       end
+      if content_type.try(&.starts_with?(MULTIPART_FORM))
+        parse_file_upload
+        return
+      end
     end
 
     private def parse_query
@@ -53,6 +59,18 @@ module Kemal
 
     private def parse_url
       @url.each { |key, value| @url[key] = unescape_url_param(value) }
+    end
+
+    private def parse_file_upload
+      HTTP::FormData.parse(@request) do |upload|
+        next unless upload
+        filename = upload.filename
+        if !filename.nil?
+          @files << FileUpload.new(upload: upload)
+        else
+          @body.add(upload.name, upload.body.gets_to_end)
+        end
+      end
     end
 
     # Parses JSON request body if Content-Type is `application/json`.


### PR DESCRIPTION
Fixes #496 and adds back `env.params.files` with caching.

P.S: This is targeted for Crystal 0.27.0