### PR TITLE
fix env.params.files

### DIFF
--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -6,7 +6,7 @@ module Kemal
     URL_ENCODED_FORM = "application/x-www-form-urlencoded"
     APPLICATION_JSON = "application/json"
     MULTIPART_FORM   = "multipart/form-data"
-    PARTS            = %w(url query body json)
+    PARTS            = %w(url query body json files)
     # :nodoc:
     alias AllParamTypes = Nil | String | Int64 | Float64 | Bool | Hash(String, JSON::Any) | Array(JSON::Any)
     getter files


### PR DESCRIPTION
### Memoize files part

Without these changes, the following code will not work:

```crystal
post "/upload" do |env|
  file = env.params.files["file"].tempfile

  File.open(file.path, "w") do |f|
    IO.copy(file, f)
  end

  "Upload OK - #{file.path}"
end
```

`env.params.files` will always be an empty hash
