### PR TITLE
Fixing exclude method in Handler

### DIFF
--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -20,6 +20,8 @@ module Kemal
 
     macro exclude(paths, method = "GET")
       class_name = {{@type.name}}
+      method_downcase = {{method}}.downcase
+      class_name_method = "#{class_name}/#{method_downcase}"
       ({{paths}}).each do |path|
         @@exclude_routes_tree.add class_name_method + path, '/' + method_downcase + path
       end


### PR DESCRIPTION
### Description of the Change

After #487 some variables were missing in `macro exclude`, I'm just adding the variables, a copy paste from` macro only`


### Benefits
No error while using exclude
