### PR TITLE
allow to set filename for send_file

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "./handler_spec"
 
 describe "Macros" do
   describe "#public_folder" do
@@ -113,6 +114,17 @@ describe "Macros" do
       response.status_code.should eq(200)
       response.headers["Content-Type"].should eq("application/octet-stream")
       response.headers["Content-Length"].should eq("6")
+    end
+
+    it "sends file with given path and given filename" do
+      get "/" do |env|
+        send_file env, "./spec/asset/hello.ecr", filename: "image.jpg"
+      end
+
+      request = HTTP::Request.new("GET", "/")
+      response = call_request_on_app(request)
+      response.status_code.should eq(200)
+      response.headers["Content-Disposition"].should eq("attachment; filename=\"image.jpg\"")
     end
   end
 


### PR DESCRIPTION
if the disposition type matches "attachment", this
indicates that the recipient should prompt the user to save the response
locally, rather than process it normally.

Without proposed changes it can be done like this:

```crystal
get "/download" do |env|
  env.response.headers.add("Content-Disposition", "attachment; filename=\"image.jpg\"")

  send_file env, "./asset/image.jpeg"
end
```

With this changes:

```crystal
get "/download" do |env|
 send_file env, "./asset/image.jpeg", filename: "image.jpg"
end
```