### PR TITLE
Fix misspelled `authors` key in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,9 @@
 name: kemal
 version: 0.25.1
 
+authors:
+  - Serdar Dogruyol <dogruyolserdar@gmail.com>
+
 dependencies:
   radix:
     github: luislavena/radix
@@ -17,6 +20,3 @@ targets:
     main: src/kemal.cr
 
 crystal: 0.27.1
-
-author:
-  - Serdar Dogruyol <dogruyolserdar@gmail.com>


### PR DESCRIPTION
SSIA, see https://github.com/crystal-lang/shards/blob/a2a5e7990ab9a234bea8fbcaea521cc98513607f/SPEC.md#authors