### PR TITLE
Revert "Add targets to shard.yml"

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,8 +15,4 @@ dependencies:
     github: crystal-loot/exception_page
     version: ~> 0.1.1
 
-targets:
-  kemal:
-    main: src/kemal.cr
-
 crystal: 0.27.1


### PR DESCRIPTION
This reverts commit ff37027afeb501a6a3461aceb21ec044dd1c24a3.

There's no point in having it defined.