### PR TITLE
Specify license in shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -16,3 +16,5 @@ dependencies:
     version: ~> 0.1.1
 
 crystal: 0.27.1
+
+license: MIT


### PR DESCRIPTION
I've just noticed there's a `license` key missing in `shard.yml`. This PR fixes that.