### PR TITLE
Properly measure request time using Time.monotonic

### DIFF
--- a/src/kemal/log_handler.cr
+++ b/src/kemal/log_handler.cr
@@ -5,9 +5,8 @@ module Kemal
     end
 
     def call(context : HTTP::Server::Context)
-      time = Time.monotonic
-      call_next(context)
-      elapsed_text = elapsed_text(Time.monotonic - time)
+      elapsed_time = Time.measure { call_next(context) }
+      elapsed_text = elapsed_text(elapsed_time)
       @io << Time.now << ' ' << context.response.status_code << ' ' << context.request.method << ' ' << context.request.resource << ' ' << elapsed_text << '\n'
       context
     end

--- a/src/kemal/log_handler.cr
+++ b/src/kemal/log_handler.cr
@@ -5,10 +5,10 @@ module Kemal
     end
 
     def call(context : HTTP::Server::Context)
-      time = Time.now
+      time = Time.monotonic
       call_next(context)
-      elapsed_text = elapsed_text(Time.now - time)
-      @io << time << ' ' << context.response.status_code << ' ' << context.request.method << ' ' << context.request.resource << ' ' << elapsed_text << '\n'
+      elapsed_text = elapsed_text(Time.monotonic - time)
+      @io << Time.now << ' ' << context.response.status_code << ' ' << context.request.method << ' ' << context.request.resource << ' ' << elapsed_text << '\n'
       context
     end
 


### PR DESCRIPTION
### Description of the Change

Citing from the crystal docs 

```
When Time.now is called multiple times, the difference between the 
returned instances is not guranteed to equal to the time elapsed between
making the calls; even the order of the returned Time instances might 
not reflect invocation order.
```

This is what happens in the base log handler. This uses `Time.monotonic` instead.

Disadvantage of this implementation: We have an additional call of `Time.now` to find out the current date for logging purposes. Maybe that was the reason this has not been implemented. if that is the case, feel free to close.