### PR TITLE
Only follow symlinks within configured static file handler directory

### DIFF
--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -39,6 +39,13 @@ module Kemal
                     end
 
       file_path = File.join(@public_dir, expanded_path)
+
+      # prevent symlinks out of the public dir
+      if File.symlink?(file_path) && !File.real_path(file_path).starts_with?(@public_dir)
+        call_next(context)
+        return
+      end
+
       is_dir = Dir.exists? file_path
 
       if request_path != expanded_path

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -42,7 +42,7 @@ module Kemal
 
       # prevent symlinks out of the public dir
       if File.symlink?(file_path) && !File.real_path(file_path).starts_with?(@public_dir)
-        call_next(context)
+        context.response.status_code = 404
         return
       end
 


### PR DESCRIPTION
This adds an additional check to only follow symlinks that are within
the configured public directory of a static file handler.

This ensures a malicious user cannot link to any files outside of the
public directory to prevent reading arbitrary files.
