### PR TITLE
Fix static file handler for range requests on files > 2^31 bytes

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -184,26 +184,26 @@ end
 private def multipart(file, env : HTTP::Server::Context)
   # See http://httpwg.org/specs/rfc7233.html
   fileb = file.size
-  startb = endb = 0
+  startb = endb = 0_i64
 
   if match = env.request.headers["Range"].match /bytes=(\d{1,})-(\d{0,})/
-    startb = match[1].to_i { 0 } if match.size >= 2
-    endb = match[2].to_i { 0 } if match.size >= 3
+    startb = match[1].to_i64 { 0_i64 } if match.size >= 2
+    endb = match[2].to_i64 { 0_i64 } if match.size >= 3
   end
 
   endb = fileb - 1 if endb == 0
 
   if startb < endb < fileb
-    content_length = 1 + endb - startb
+    content_length = 1_i64 + endb - startb
     env.response.status_code = 206
     env.response.content_length = content_length
     env.response.headers["Accept-Ranges"] = "bytes"
     env.response.headers["Content-Range"] = "bytes #{startb}-#{endb}/#{fileb}" # MUST
 
     if startb > 1024
-      skipped = 0
+      skipped = 0_i64
       # file.skip only accepts values less or equal to 1024 (buffer size, undocumented)
-      until (increase_skipped = skipped + 1024) > startb
+      until (increase_skipped = skipped + 1024_i64) > startb
         file.skip(1024)
         skipped = increase_skipped
       end


### PR DESCRIPTION
### To reproduce on master:

```crystal
require "kemal"
Kemal.run
```

Serving a file > ~2.1 GB, for example:

```
$ dd if=/dev/urandom of=file2 bs=1000 count=2147484 status=progress
```

Request with:

```
$ curl http://localhost:3000/file2 -H 'Range: bytes=0-' -v -o /dev/null
```

which produces:
```
Exception: Negative limit (ArgumentError)
  from /usr/lib/crystal/io.cr:1147:5 in 'copy'
  from /helpers.cr:218:5 in 'multipart'
  from src/kemal/helpers/helpers.cr:137:12 in 'send_file'
  from src/kemal/static_file_handler.cr:65:9 in 'call'
  from /usr/lib/crystal/http/server/handler.cr:26:7 in 'call_next'
  from src/kemal/exception_handler.cr:8:7 in 'call'
  from /usr/lib/crystal/http/server/handler.cr:26:7 in 'call_next'
  from src/kemal/log_handler.cr:8:37 in 'call'
  from /usr/lib/crystal/http/server/handler.cr:26:7 in 'call_next'
  from src/kemal/init_handler.cr:12:7 in 'call'
  from /usr/lib/crystal/http/server/request_processor.cr:39:11 in 'process'
  from /usr/lib/crystal/http/server/request_processor.cr:16:3 in 'process'
  from /usr/lib/crystal/http/server.cr:462:5 in 'handle_client'
  from /usr/lib/crystal/http/server.cr:428:13 in '->'
  from /usr/lib/crystal/fiber.cr:255:3 in 'run'
  from /usr/lib/crystal/fiber.cr:47:34 in '->'
  from ???

2019-07-31 18:36:19 UTC 500 GET /file2 112.57ms
```

### Description

The static file handler will serve an incorrect content length when encountering a range request on files > 2^31 bytes (`Int32::MAX`) due to an integer overflow.

Since `file.size` returns a `UInt64`, I've updated the rest of the code to use the same type.