### PR TITLE
Upgrade to Crystal v0.30.0

### DIFF
--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -24,7 +24,7 @@ module Kemal
     end
 
     private def unescape_url_param(value : String)
-      value.empty? ? value : URI.unescape(value)
+      value.empty? ? value : URI.decode(value)
     rescue
       value
     end

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -21,7 +21,7 @@ module Kemal
 
       config = Kemal.config.serve_static
       original_path = context.request.path.not_nil!
-      request_path = URI.unescape(original_path)
+      request_path = URI.decode(original_path)
 
       # File path cannot contains '\0' (NUL) because all filesystem I know
       # don't accept '\0' character as file name.


### PR DESCRIPTION
A `Crystal::VERSION` check should be added if you want kemal to be warning free but also keep working in 0.29.0.

You can double check in https://github.com/crystal-lang/crystal/pull/7997 which encode/decode method apply better for each situation.