### PR TITLE
Check for KEMAL_ENV variable already in Config#initialize 

### DIFF
--- a/src/kemal/cli.cr
+++ b/src/kemal/cli.cr
@@ -8,7 +8,6 @@ module Kemal
       @key_file = ""
       @cert_file = ""
       @config = Kemal.config
-      read_env
       if args
         parse args
       end
@@ -51,12 +50,6 @@ module Kemal
           Kemal.config.ssl = ssl.context
         end
       {% end %}
-    end
-
-    private def read_env
-      if kemal_env = ENV["KEMAL_ENV"]?
-        @config.env = kemal_env
-      end
     end
   end
 end

--- a/src/kemal/cli.cr
+++ b/src/kemal/cli.cr
@@ -42,15 +42,15 @@ module Kemal
 
     private def configure_ssl
       {% if !flag?(:without_openssl) %}
-      if @ssl_enabled
-        abort "SSL Key Not Found" if !@key_file
-        abort "SSL Certificate Not Found" if !@cert_file
-        ssl = Kemal::SSL.new
-        ssl.key_file = @key_file.not_nil!
-        ssl.cert_file =  @cert_file.not_nil!
-        Kemal.config.ssl = ssl.context
-      end
-    {% end %}
+        if @ssl_enabled
+          abort "SSL Key Not Found" if !@key_file
+          abort "SSL Certificate Not Found" if !@cert_file
+          ssl = Kemal::SSL.new
+          ssl.key_file = @key_file.not_nil!
+          ssl.cert_file = @cert_file.not_nil!
+          Kemal.config.ssl = ssl.context
+        end
+      {% end %}
     end
 
     private def read_env

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -29,7 +29,7 @@ module Kemal
     def initialize
       @host_binding = "0.0.0.0"
       @port = 3000
-      @env = "development"
+      @env = ENV["KEMAL_ENV"]? || "development"
       @serve_static = {"dir_listing" => false, "gzip" => true}
       @public_folder = "./public"
       @logging = true


### PR DESCRIPTION
This PR intends to simplify working with `Kemal.config.env` property.

As of now this property stays always initialized to `"development"`, regardless of `KEMAL_ENV` env variable setting. It's being set only once `Kemal::CLI` initializes (which happens on server start) - making it impossible to properly use it before.

After this change `KEMAL_ENV` will be read immediately on `Config` init. 