### PR TITLE
flush io buffer after each write to log

### DIFF
--- a/src/kemal/log_handler.cr
+++ b/src/kemal/log_handler.cr
@@ -8,11 +8,14 @@ module Kemal
       elapsed_time = Time.measure { call_next(context) }
       elapsed_text = elapsed_text(elapsed_time)
       @io << Time.utc << ' ' << context.response.status_code << ' ' << context.request.method << ' ' << context.request.resource << ' ' << elapsed_text << '\n'
+      @io.flush
       context
     end
 
     def write(message : String)
       @io << message
+      @io.flush
+      @io
     end
 
     private def elapsed_text(elapsed)


### PR DESCRIPTION
### Description of the Change

As tittle says, flushes IO buffers whenever a log entry is written.

### Benefits

If the stdout is not a tty, for example if the program is running inside a systemd unit, the buffered log entries would not appear until buffers are full. This change fixes that and for systemd units, the log is immediately visible in the journal.

### Possible Drawbacks

Constantly flushing could be a performance issue, however, I think for a production environment, most would want to use a proxy or something else for logging.