### PR TITLE
allow to set optional response body on redirects

### DIFF
--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -118,6 +118,18 @@ describe "Kemal::RouteHandler" do
     request = HTTP::Request.new("GET", "/")
     client_response = call_request_on_app(request)
     client_response.status_code.should eq(302)
+    client_response.body.should eq("")
+    client_response.headers.has_key?("Location").should eq(true)
+  end
+
+  it "redirects with body" do
+    get "/" do |env|
+      env.redirect "/login", body: "Redirecting to /login"
+    end
+    request = HTTP::Request.new("GET", "/")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(302)
+    client_response.body.should eq("Redirecting to /login")
     client_response.headers.has_key?("Location").should eq(true)
   end
 end

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -17,9 +17,10 @@ class HTTP::Server
       @params ||= Kemal::ParamParser.new(@request, route_lookup.params)
     end
 
-    def redirect(url : String, status_code : Int32 = 302)
+    def redirect(url : String, status_code : Int32 = 302, *, body : String? = nil)
       @response.headers.add "Location", url
       @response.status_code = status_code
+      @response.print(body) if body
     end
 
     def route


### PR DESCRIPTION
Q: HTTP 302 Redirect - is a message-body needed?
A: A body is needed, but it can be empty.