### PR TITLE
Update to ameba ~> 0.12.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.10.0
+    version: ~> 0.12.0
 
 crystal: 0.30.0
 


### PR DESCRIPTION
ameba 0.12.0 is able to compile warning free in Crystal 0.34.0