### PR TITLE
Omitting filters fix for lowercase methods requests

### DIFF
--- a/spec/filter_spec.cr
+++ b/spec/filter_spec.cr
@@ -1,0 +1,49 @@
+require "./spec_helper"
+
+describe "Kemal::FilterHandler" do
+  it "handles with downcased 'post'" do
+    before_post do |env|
+      env.set "sensitive", "1"
+    end
+
+    post "/sensitive_post" do |env|
+      env.get "sensitive"
+    end
+
+    # For some reason somewhere in `Spec.after_each` handler,
+    # `call_request_on_app()` doesn't work with sequentially called specs:
+    # only one test can be passed for the same time.
+    # Use this sequence instead
+    request = HTTP::Request.new("post", "/sensitive_post")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::FilterHandler::INSTANCE.call(context)
+    Kemal::RouteHandler::INSTANCE.call(context)
+
+    context.get("sensitive").should eq "1"
+  end
+
+  it "handles with upcased 'POST'" do
+    before_post do |env|
+      env.set "sensitive", "1"
+    end
+
+    post "/sensitive_post" do |env|
+      env.get "sensitive"
+    end
+
+    # For some reason somewhere in `Spec.after_each` handler,
+    # `call_request_on_app()` doesn't work with sequentially called specs:
+    # only one test can be passed for the same time.
+    # Use this sequence instead
+    request = HTTP::Request.new("POST", "/sensitive_post")
+    io = IO::Memory.new
+    response = HTTP::Server::Response.new(io)
+    context = HTTP::Server::Context.new(request, response)
+    Kemal::FilterHandler::INSTANCE.call(context)
+    Kemal::RouteHandler::INSTANCE.call(context)
+
+    context.get("sensitive").should eq "1"
+  end
+end

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -71,7 +71,7 @@ module Kemal
     end
 
     private def radix_path(verb : String?, path : String, type : Symbol)
-      "#{type}/#{verb}/#{path}"
+      "#{type}/#{verb.upcase}/#{path}"
     end
 
     # :nodoc:


### PR DESCRIPTION
### Description of the Change

#### Short

This PR fixes unexpected filters skipping. Specs added that describe the difference.

#### Long

Imagine an app which calculates number of specific `POST` calls.

```crystal
visited = 0

before_post do |env|
  log "We'd also like to log all POST requests"

  unless env.params.json["user"]? == "Shadow"
    halt env, 401, "Only authorized users!"
  end
end

post "/sensitive" do |env|
  visited += 1
  "Secret! #{ visited }"
end
```

Now check it:
`curl -X post http://localhost:3000/sensitive` (pay attention to `post` instead of `POST`)
Response: `Secret! 1` -- **whoops!**

Another check:
`curl -X POST http://localhost:3000/sensitive`
Resonse: `Only authorized users!` -- we can still get here

### Alternate Designs

Maybe this is bug in Crystal itself:

* Rails (Rack) does not allow lowercase request methods
* Nginx does not allow it
* Both of them respond with 400

But it seems not very correct to transfer all responsibility to Crystal stdlib and leave this behaviour as is.

Another solution is to completely follow HTTP specification and allow uppercase requests only.
Guess it should be managed by `HTTP::Server` but i'm not sure: what default `400 bad request` page should it have? Like a Nginx (html page)? Or like a Ruby/Rails (zero response)?

### Benefits

Possible unpredictable vulnerability fix. There is not only curl can make lowercase requests but any self-written socket server.

### Possible Drawbacks

Current behaviour can be used by someone as correct and someone can already call Kemal services through S2S with lowercase methods. If this so, please note that HTTP specification ([RFC2616, section 5.1.1](https://tools.ietf.org/html/rfc2616#section-5.1.1)) does not allow it and describes HTTP methods like uppercase and case sensitive.