### PR TITLE
Pick up Transitional Type Aliases

### DIFF
--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -1,3 +1,5 @@
+require "flate"
+require "gzip"
 require "mime"
 
 # Adds given `Kemal::Handler` to handlers chain.


### PR DESCRIPTION
This change explicitly requires dependent code so that transitional types aliases (and deprecation warnings) are included. Paves the way for the release of 0.35.0.

See: https://github.com/crystal-lang/crystal/pull/8886 (specifically the type aliases).

### Description of the Change
Simply explicitly requires dependent code. When not present, building against the currently nightly crystal build results in errors like the following (including when running the specs):
```
...
...
In src/kemal/helpers/helpers.cr:135:8
 135 | File.open(file_path) do |file|
            ^---
Error: instantiating 'File.class#open(String)'

In src/kemal/helpers/helpers.cr:143:7
 143 | Gzip::Writer.open(env.response) do |deflate|
       ^-----------
Error: undefined constant Gzip::Writer
```

### Benefits
This change does not affect existing functionality, but avoids problems when building against the current nightly crystal build, and presumably 0.35.0 when it's released.