### PR TITLE
Upgrade to Crystal 0.35.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.10.0
+    version: ~> 0.12.0
 
 crystal: 0.30.0
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -48,6 +48,9 @@ def create_ws_request_and_return_io_and_context(handler, request)
   rescue IO::Error
     # Raises because the IO::Memory is empty
   end
+  {% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+    response.upgrade_handler.try &.call(io)
+  {% end %}
   io.rewind
   {io, context}
 end

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -1,5 +1,7 @@
-require "flate"
-require "gzip"
+{% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+  require "compress/deflate"
+  require "compress/gzip"
+{% end %}
 require "mime"
 
 # Adds given `Kemal::Handler` to handlers chain.
@@ -142,14 +144,26 @@ def send_file(env : HTTP::Server::Context, path : String, mime_type : String? = 
     condition = config.is_a?(Hash) && config["gzip"]? == true && filesize > minsize && Kemal::Utils.zip_types(file_path)
     if condition && request_headers.includes_word?("Accept-Encoding", "gzip")
       env.response.headers["Content-Encoding"] = "gzip"
-      Gzip::Writer.open(env.response) do |deflate|
-        IO.copy(file, deflate)
-      end
+      {% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+        Compress::Gzip::Writer.open(env.response) do |deflate|
+          IO.copy(file, deflate)
+        end
+      {% else %}
+        Gzip::Writer.open(env.response) do |deflate|
+          IO.copy(file, deflate)
+        end
+      {% end %}
     elsif condition && request_headers.includes_word?("Accept-Encoding", "deflate")
       env.response.headers["Content-Encoding"] = "deflate"
-      Flate::Writer.open(env.response) do |deflate|
-        IO.copy(file, deflate)
-      end
+      {% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
+        Compress::Deflate::Writer.open(env.response) do |deflate|
+          IO.copy(file, deflate)
+        end
+      {% else %}
+        Flate::Writer.open(env.response) do |deflate|
+          IO.copy(file, deflate)
+        end
+      {% end %}
     else
       env.response.content_length = filesize
       IO.copy(file, env.response)

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -1,7 +1,3 @@
-{% if !flag?(:without_zlib) %}
-  require "zlib"
-{% end %}
-
 module Kemal
   class StaticFileHandler < HTTP::StaticFileHandler
     # ameba:disable Metrics/CyclomaticComplexity


### PR DESCRIPTION
These are some of the changes to upgrade to Crystal 0.35 without warnings.

FYI ameba is also waiting on some changes to be released to avoid warnings.
