### PR TITLE
Refactor run_spec to use process exit instead of empty stderr

### DIFF
--- a/spec/run_spec.cr
+++ b/spec/run_spec.cr
@@ -5,12 +5,12 @@ private def run(code)
     require "./src/kemal"
     #{code}
     CR
-  String.build do |stdout|
-    stderr = String.build do |io|
-      Process.new("crystal", ["eval"], input: IO::Memory.new(code), output: stdout, error: io).wait
-    end
-    fail(stderr) unless stderr.empty?
-  end
+
+  stdout = IO::Memory.new
+  stderr = IO::Memory.new
+  status = Process.new("crystal", ["eval"], input: IO::Memory.new(code), output: stdout, error: stderr).wait
+  fail(stderr.to_s) unless status.success?
+  stdout.to_s
 end
 
 describe "Run" do


### PR DESCRIPTION
Bonus: It also allows run_spec to pass if using bin/crystal wrapper (since the wrapper emits some warnings of `Using compiled compiler at ...`) and that caused the spec to fail without this PR.