### PR TITLE
Use Radix v0.4.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -7,7 +7,7 @@ authors:
 dependencies:
   radix:
     github: luislavena/radix
-    version: ~> 0.3.8
+    version: ~> 0.4.0
   kilt:
     github: jeromegn/kilt
     version: ~> 0.4.0


### PR DESCRIPTION
### Description of the Change

Use latest release version of Radix in order to address some of the
routing bugs presented in previous versions of the dependency

See:

- luislavena/radix#23
- luislavena/radix#27

### Benefits

Corrects the bugs experienced in the above issues 😁 

### Possible Drawbacks

None that I can see from running the specs and a few manual tests.

Radix has been tested against Crystal 0.35.0 through 0.36.1 without issues (Kemal is failing on latest versions, but that is a separate issue).

Cheers,
❤️ ❤️ ❤️ 