### PR TITLE
Use latest version of Ameba dependency (dev)

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.12.0
+    version: ~> 0.13.4
 
 crystal: 0.35.0
 


### PR DESCRIPTION
### Description of the Change

With this change is possible to continue development of Kemal in latest version of Crystal (0.36.1).

### Possible Drawbacks

Without this change is not possible to install Kemal for local development:

```
~/repos/github.com/kemalcr/kemal on  use-latest-ameba [$] via 🔮 v0.36.1
❯ shards install
Resolving dependencies
Fetching https://github.com/luislavena/radix.git
Fetching https://github.com/jeromegn/kilt.git
Fetching https://github.com/crystal-loot/exception_page.git
Fetching https://github.com/crystal-ameba/ameba.git
Using radix (0.3.9)
Using kilt (0.4.0)
Using exception_page (0.1.4)
Installing ameba (0.12.1)
Postinstall of ameba: make bin && make run_file
Failed postinstall of ameba on make bin && make run_file:
/home/luis/.asdf/installs/crystal/0.36.1/bin/shards build
Dependencies are satisfied
Building: ameba
Error target ameba failed to compile:
Showing last frame. Use --error-trace for full trace.

In /home/luis/.asdf/installs/crystal/0.36.1/share/crystal/src/yaml/from_yaml.cr:12:3

 12 | new(YAML::ParseContext.new, parse_yaml(string_or_io))
      ^--
Error: wrong number of arguments for 'Ameba::Rule::Lint::Syntax.new' (given 2, expected 0..1)

Overloads are:
 - Ameba::Rule::Lint::Syntax.new(config = nil)

make: *** [Makefile:8: bin/ameba] Error 1
```

After this change:

```
~/repos/github.com/kemalcr/kemal on  use-latest-ameba via 🔮 v0.36.1
❯ shards install
Resolving dependencies
Fetching https://github.com/luislavena/radix.git
Fetching https://github.com/jeromegn/kilt.git
Fetching https://github.com/crystal-loot/exception_page.git
Fetching https://github.com/crystal-ameba/ameba.git
Installing radix (0.3.9)
Installing kilt (0.4.0)
Installing exception_page (0.1.4)
Installing ameba (0.13.4)
Postinstall of ameba: make bin && make run_file

~/repos/github.com/kemalcr/kemal on  use-latest-ameba via 🔮 v0.36.1 took 9s
❯ echo $?
0
```

Cheers,
❤️ ❤️ ❤️ 