### PR TITLE
Fix StaticFileHandler failing spec

### DIFF
--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -59,7 +59,7 @@ describe Kemal::StaticFileHandler do
   it "should not gzip a file if config is true, headers accept gzip and file is < 880 bytes" do
     serve_static({"gzip" => true, "dir_listing" => true})
     headers = HTTP::Headers{"Accept-Encoding" => "gzip, deflate, sdch, br"}
-    response = handle HTTP::Request.new("GET", "/dir/test.txt", headers)
+    response = handle HTTP::Request.new("GET", "/dir/test.txt", headers), decompress: false
     response.status_code.should eq(200)
     response.headers["Content-Encoding"]?.should be_nil
   end
@@ -67,7 +67,7 @@ describe Kemal::StaticFileHandler do
   it "should not gzip a file if config is false, headers accept gzip and file is > 880 bytes" do
     serve_static({"gzip" => false, "dir_listing" => true})
     headers = HTTP::Headers{"Accept-Encoding" => "gzip, deflate, sdch, br"}
-    response = handle HTTP::Request.new("GET", "/dir/bigger.txt", headers)
+    response = handle HTTP::Request.new("GET", "/dir/bigger.txt", headers), decompress: false
     response.status_code.should eq(200)
     response.headers["Content-Encoding"]?.should be_nil
   end

--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -1,6 +1,6 @@
 require "./spec_helper"
 
-private def handle(request, fallthrough = true)
+private def handle(request, fallthrough = true, decompress = true)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
@@ -8,7 +8,7 @@ private def handle(request, fallthrough = true)
   handler.call context
   response.close
   io.rewind
-  HTTP::Client::Response.from_io(io)
+  HTTP::Client::Response.from_io(io, decompress: decompress)
 end
 
 describe Kemal::StaticFileHandler do
@@ -51,7 +51,7 @@ describe Kemal::StaticFileHandler do
   it "should gzip a file if config is true, headers accept gzip and file is > 880 bytes" do
     serve_static({"gzip" => true, "dir_listing" => true})
     headers = HTTP::Headers{"Accept-Encoding" => "gzip, deflate, sdch, br"}
-    response = handle HTTP::Request.new("GET", "/dir/bigger.txt", headers)
+    response = handle HTTP::Request.new("GET", "/dir/bigger.txt", headers), decompress: false
     response.status_code.should eq(200)
     response.headers["Content-Encoding"].should eq "gzip"
   end


### PR DESCRIPTION
### Description of the Change

Change fixes the build failing due to http module now removing ContentEncoding is decompress param is set to true, see also Issue #594

### Benefits

Build should work again now.

### Possible Drawbacks

No checks are actually performed on the body of the response. But really, this I think was not the spec of the spec