### PR TITLE
Bump ameba dependency to the latest version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -18,7 +18,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.13.4
+    version: ~> 0.14.0
 
 crystal: 0.35.0
 

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -22,8 +22,8 @@ describe "Kemal::WebSocketHandler" do
 
   it "matches on given route" do
     handler = Kemal::WebSocketHandler::INSTANCE
-    ws "/" { |socket| socket.send("Match") }
-    ws "/no_match" { |socket| socket.send "No Match" }
+    ws("/", &.send("Match"))
+    ws("/no_match", &.send("No Match"))
     headers = HTTP::Headers{
       "Upgrade"               => "websocket",
       "Connection"            => "Upgrade",

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -66,7 +66,7 @@ module Kemal
   end
 
   def self.display_startup_message(config, server)
-    addresses = server.addresses.map { |address| "#{config.scheme}://#{address}" }.join ", "
+    addresses = server.addresses.join ", " { |address| "#{config.scheme}://#{address}" }
     log "[#{config.env}] Kemal is ready to lead at #{addresses}"
   end
 


### PR DESCRIPTION
### Description of the Change

Updating ameba dependency to the latest version.

### Benefits

Stayin' up to date with ameba linter.

### Possible Drawbacks

`Enumerable#join(separator, &)` might be less performant than its optimized version in `Indexable#join(separator)`, but since the only place that's being changed is the non-critical path I'd consider this as a non-issue.
