### PR TITLE
Add array of paths support for before/after filters

### DIFF
--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -34,7 +34,7 @@ end
      Kemal::FilterHandler::INSTANCE.{{type.id}}({{method}}.upcase, path, &block)
     end
 
-    def {{type.id}}_{{method.id}}(paths : Array(String) = ["*"], &block : HTTP::Server::Context -> _)
+    def {{type.id}}_{{method.id}}(paths : Array(String), &block : HTTP::Server::Context -> _)
       paths.each do |path|
         Kemal::FilterHandler::INSTANCE.{{type.id}}({{method}}.upcase, path, &block)
       end

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -33,5 +33,11 @@ end
     def {{type.id}}_{{method.id}}(path : String = "*", &block : HTTP::Server::Context -> _)
      Kemal::FilterHandler::INSTANCE.{{type.id}}({{method}}.upcase, path, &block)
     end
+
+    def {{type.id}}_{{method.id}}(paths : Array(String) = ["*"], &block : HTTP::Server::Context -> _)
+      paths.each do |path|
+        Kemal::FilterHandler::INSTANCE.{{type.id}}({{method}}.upcase, path, &block)
+      end
+    end
   {% end %}
 {% end %}


### PR DESCRIPTION
### Description of the Change

Adds array of paths support to before/after filters. With this change you can do

```crystal
before ["/path1", "path2", "path3"], "GET" do 
  puts "Doing something for get routes"
end
```

This will reduce code copy/paste. DRY 👍 
