### PR TITLE
New option to set application name

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -58,4 +58,11 @@ describe "Config" do
   it "gets the version from shards.yml" do
     Kemal::VERSION.should_not be("")
   end
+
+  it "sets application name" do
+    config = Kemal.config
+    config.app_name.should eq "Kemal"
+    config.app_name = "testapp"
+    config.app_name.should eq "testapp"
+  end
 end

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -67,11 +67,11 @@ module Kemal
 
   def self.display_startup_message(config, server)
     addresses = server.addresses.join ", " { |address| "#{config.scheme}://#{address}" }
-    log "[#{config.env}] Kemal is ready to lead at #{addresses}"
+    log "[#{config.env}] #{config.app_name} is ready to lead at #{addresses}"
   end
 
   def self.stop
-    raise "Kemal is already stopped." if !config.running
+    raise "#{Kemal.config.app_name} is already stopped." if !config.running
     if server = config.server
       server.close unless server.closed?
       config.running = false
@@ -90,7 +90,7 @@ module Kemal
 
   private def self.setup_trap_signal
     Signal::INT.trap do
-      log "Kemal is going to take a rest!" if Kemal.config.shutdown_message
+      log "#{Kemal.config.app_name} is going to take a rest!" if Kemal.config.shutdown_message
       Kemal.stop
       exit
     end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -24,9 +24,10 @@ module Kemal
     property always_rescue, server : HTTP::Server?, extra_options, shutdown_message
     property serve_static : (Bool | Hash(String, Bool))
     property static_headers : (HTTP::Server::Response, String, File::Info -> Void)?
-    property powered_by_header : Bool = true
+    property powered_by_header : Bool = true, app_name
 
     def initialize
+      @app_name = "Kemal"
       @host_binding = "0.0.0.0"
       @port = 3000
       @env = ENV["KEMAL_ENV"]? || "development"


### PR DESCRIPTION
Showing "Kemal" in startup and shutdown messages confuses user
when the static binary is deployed at customer setup.

This PR adds a option to set App name so that it will be shown
when the application starts and shutdown.

Example:

```
require "kemal"

get "/" do
  "Hello App!"
end

Kemal.config.app_name = "helloapp"
Kemal.run
```

Shows message as follows

```
[development] helloapp is ready to lead at http://0.0.0.0:3000
```

Signed-off-by: Aravinda Vishwanathapura <mail@aravindavk.in>
