### PR TITLE
Bump exception_page shard to ~> 0.2.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -13,7 +13,7 @@ dependencies:
     version: ~> 0.4.0
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.1.1
+    version: ~> 0.2.0
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
### Description of the Change

Updates [exception_page](https://github.com/crystal-loot/exception_page) shard to ~> 0.2.0

### Benefits

Fixed https://github.com/crystal-loot/exception_page/issues/8

### Possible Drawbacks

None that I can see.
