### PR TITLE
Allow running specs from any directory

### DIFF
--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -100,7 +100,7 @@ describe "Macros" do
   describe "#send_file" do
     it "sends file with given path and default mime-type" do
       get "/" do |env|
-        send_file env, "./spec/asset/hello.ecr"
+        send_file env, "#{__DIR__}/asset/hello.ecr"
       end
 
       request = HTTP::Request.new("GET", "/")
@@ -112,7 +112,7 @@ describe "Macros" do
 
     it "sends file with given path and given mime-type" do
       get "/" do |env|
-        send_file env, "./spec/asset/hello.ecr", "image/jpeg"
+        send_file env, "#{__DIR__}/asset/hello.ecr", "image/jpeg"
       end
 
       request = HTTP::Request.new("GET", "/")
@@ -136,7 +136,7 @@ describe "Macros" do
 
     it "sends file with given path and given filename" do
       get "/" do |env|
-        send_file env, "./spec/asset/hello.ecr", filename: "image.jpg"
+        send_file env, "#{__DIR__}/asset/hello.ecr", filename: "image.jpg"
       end
 
       request = HTTP::Request.new("GET", "/")

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -1,14 +1,14 @@
 require "./spec_helper"
 
 macro render_with_base_and_layout(filename)
-  render "spec/asset/#{{{filename}}}", "spec/asset/layout.ecr"
+  render "#{__DIR__}/asset/#{{{filename}}}", "#{__DIR__}/asset/layout.ecr"
 end
 
 describe "Views" do
   it "renders file" do
     get "/view/:name" do |env|
       name = env.params.url["name"]
-      render "spec/asset/hello.ecr"
+      render "#{__DIR__}/asset/hello.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
     client_response = call_request_on_app(request)
@@ -28,7 +28,7 @@ describe "Views" do
   it "renders layout" do
     get "/view/:name" do |env|
       name = env.params.url["name"]
-      render "spec/asset/hello.ecr", "spec/asset/layout.ecr"
+      render "#{__DIR__}/asset/hello.ecr", "#{__DIR__}/asset/layout.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
     client_response = call_request_on_app(request)
@@ -40,7 +40,7 @@ describe "Views" do
       name = env.params.url["name"]
       var1 = "serdar"
       var2 = "kemal"
-      render "spec/asset/hello_with_content_for.ecr", "spec/asset/layout_with_yield_and_vars.ecr"
+      render "#{__DIR__}/asset/hello_with_content_for.ecr", "#{__DIR__}/asset/layout_with_yield_and_vars.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
     client_response = call_request_on_app(request)
@@ -52,7 +52,7 @@ describe "Views" do
   it "renders layout with content_for" do
     get "/view/:name" do |env|
       name = env.params.url["name"]
-      render "spec/asset/hello_with_content_for.ecr", "spec/asset/layout_with_yield.ecr"
+      render "#{__DIR__}/asset/hello_with_content_for.ecr", "#{__DIR__}/asset/layout_with_yield.ecr"
     end
     request = HTTP::Request.new("GET", "/view/world")
     client_response = call_request_on_app(request)


### PR DESCRIPTION
Prevent compile-time problems due to relative paths.
As-is, the specs assume that you're running from the root directory of the project.
It's not a big deal in almost every situation, so feel free to disregard this :)