### PR TITLE
set Content-Type "text/html" for 500 error by default

### DIFF
--- a/src/kemal/helpers/templates.cr
+++ b/src/kemal/helpers/templates.cr
@@ -22,6 +22,7 @@ def render_404
 end
 
 def render_500(context, exception, verbosity)
+  context.response.content_type = "text/html"
   context.response.status_code = 500
 
   template = if verbosity


### PR DESCRIPTION
Code to reproduce:

```
require "kemal"

before_all do |env|
  env.response.content_type = "application/json"
end

get "/status" do
  1 // 0
  {"status" => "ok"}.to_json
end

Kemal.run
```

Before:
![01](https://user-images.githubusercontent.com/61285/115517729-1d918b00-a290-11eb-84d8-174cf59678ef.png)

After:
![02](https://user-images.githubusercontent.com/61285/115517741-208c7b80-a290-11eb-9baa-72faea380a50.png)
