### PR TITLE
fixed executing filters when before and after is defined at the same time

### DIFF
--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -71,7 +71,7 @@ module Kemal
     end
 
     private def radix_path(verb : String?, path : String, type : Symbol)
-      "#{type}/#{verb}/#{path}"
+      "/#{type}/#{verb}/#{path}"
     end
 
     # :nodoc:


### PR DESCRIPTION
Code to reproduce:

```
require "kemal"

before_all do |env|
  puts "BEFORE <"
end

after_all  do |env|
  puts "> AFTER"
end

get "/" do
  "Hello World!"
end

Kemal.run
```

`after` request will never be executed.

Not sure what going on here. But the origin of the issue is in `radix` shard. It does not properly handle paths without trailing `/`.

```
require "radix"

tree = Radix::Tree(Symbol).new

tree.add "after/ALL/*", :after
tree.add "before/ALL/*", :before

pp tree.find "after/ALL/*"
pp tree.find "before/ALL/*"
```

Output

```
#<Radix::Result(Symbol):0x7fbf3bb8bf00 @key=nil, @params={}, @payload=:after>
#<Radix::Result(Symbol):0x7fbf3bb8bcf0 @key=nil, @params={}, @payload=nil>

```