### PR TITLE
Deprecate dependency on kilt

### DIFF
--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -60,6 +60,7 @@ end
 # ```
 # render "src/views/index.ecr", "src/views/layout.ecr"
 # ```
+@[Deprecated("Use `ECR#render` instead")]
 macro render(filename, layout)
   __content_filename__ = {{filename}}
   content = render {{filename}}
@@ -67,6 +68,7 @@ macro render(filename, layout)
 end
 
 # Render view with the given filename.
+@[Deprecated("Use `ECR#render` instead")]
 macro render(filename)
   Kilt.render({{filename}})
 end


### PR DESCRIPTION
This PR should remove the dependency on Kilt, as suggested in #467.

`Kilt.render` was just an alias for
```crystal
String.build do |io|
  ECR.embed({{filename}}, "io", {{*args}}) # => or what ever engine you prefer
end
```

I did try [ECR#render](https://crystal-lang.org/api/1.0.0/ECR.html#render(filename)-macro) but the tests for `content_for` would fail because `ECR#render` (for some reason) didn't see `{{*args}}`.

```crystal
ECR.render({{filename}}, {{*args}}) # => this fails
```

The proposed solution was selected because `ECR#render` is just an alias for the code in the snippet above (- the args).

Should close #467 