### PR TITLE
Set content type to text/html for 500 exceptions

### DIFF
--- a/src/kemal/helpers/templates.cr
+++ b/src/kemal/helpers/templates.cr
@@ -22,6 +22,7 @@ def render_404
 end
 
 def render_500(context, exception, verbosity)
+  context.response.content_type = "text/html"
   context.response.status_code = 500
 
   template = if verbosity


### PR DESCRIPTION
### Description of the Change

Superseeds #610, thanks @mamantoha 🙏 

### Benefits

Most of the web frameworks (Spring Boot, Rails e.g) do this. With this we do have a common ground with major web frameworks.

### Possible Drawbacks

None