### PR TITLE
Remove Kilt

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ See also [Getting Started](http://kemalcr.com/guide/).
 - Middleware support
 - Built-in JSON support
 - Built-in static file serving
-- Built-in view templating via [Kilt](https://github.com/jeromegn/kilt)
+- Built-in view templating via [ECR](https://crystal-lang.org/api/ECR.html)
 
 # Documentation
 

--- a/shard.yml
+++ b/shard.yml
@@ -8,9 +8,6 @@ dependencies:
   radix:
     github: luislavena/radix
     version: ~> 0.4.0
-  kilt:
-    github: jeromegn/kilt
-    version: ~> 0.6.0
   exception_page:
     github: crystal-loot/exception_page
     version: ~> 0.2.0

--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -1,5 +1,3 @@
-require "kilt"
-
 CONTENT_FOR_BLOCKS = Hash(String, Tuple(String, Proc(String))).new
 
 # `content_for` is a set of helpers that allows you to capture
@@ -37,9 +35,9 @@ CONTENT_FOR_BLOCKS = Hash(String, Tuple(String, Proc(String))).new
 # setting the appropriate set of tags that should be added to the layout.
 macro content_for(key, file = __FILE__)
   %proc = ->() {
-    __kilt_io__ = IO::Memory.new
+    __view_io__ = IO::Memory.new
     {{ yield }}
-    __kilt_io__.to_s
+    __view_io__.to_s
   }
 
   CONTENT_FOR_BLOCKS[{{key}}] = Tuple.new {{file}}, %proc
@@ -60,17 +58,17 @@ end
 # ```
 # render "src/views/index.ecr", "src/views/layout.ecr"
 # ```
-@[Deprecated("Use `ECR#render` instead")]
 macro render(filename, layout)
   __content_filename__ = {{filename}}
-  content = render {{filename}}
-  render {{layout}}
+  io = IO::Memory.new
+  content = ECR.embed {{filename}}, io
+  ECR.embed {{layout}}, io
+  io.to_s
 end
 
 # Render view with the given filename.
-@[Deprecated("Use `ECR#render` instead")]
 macro render(filename)
-  Kilt.render({{filename}})
+  ECR.render({{filename}})
 end
 
 # Halt execution with the current context.


### PR DESCRIPTION
### Description of the Change

This PR removes Kilt and all the reference to it. Fixes #617 

### Benefits

Kemal will now only rely on ECR which is already built-into the Crystal standard library

### Possible Drawbacks

The users must include and use `Kilt` themsevels