### PR TITLE
Fix content rendering

### DIFF
--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -22,7 +22,7 @@ describe "Views" do
     end
     request = HTTP::Request.new("GET", "/view/world")
     client_response = call_request_on_app(request)
-    client_response.body.should contain("Hello world")
+    client_response.body.strip.should eq("<html>Hello world\n</html>")
   end
 
   it "renders layout" do
@@ -58,5 +58,15 @@ describe "Views" do
     client_response = call_request_on_app(request)
     client_response.body.should contain("Hello world")
     client_response.body.should contain("<h1>Hello from otherside</h1>")
+  end
+
+  it "does not render content_for that was not yielded" do
+    get "/view/:name" do |env|
+      name = env.params.url["name"]
+      render "#{__DIR__}/asset/hello_with_content_for.ecr", "#{__DIR__}/asset/layout.ecr"
+    end
+    request = HTTP::Request.new("GET", "/view/world")
+    client_response = call_request_on_app(request)
+    client_response.body.should_not contain("<h1>Hello from otherside</h1>")
   end
 end


### PR DESCRIPTION
Fixes #630 

Turns out that you have to call `ECR.embed` and pass in an `IO::Memory` or it breaks the `content_for` macro.

Tried to update the specs to catch the problems in the future. For the record, the added spec never failed, it was added as a precaution.