### PR TITLE
Update ameba to 1.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.0
+    version: ~> 1.0
 
 crystal: ">= 0.36.0"
 


### PR DESCRIPTION
Updates ameba to version 1.0

The previous version 0.14.0 is bugged and doesn't terminate when built with Crystal 1.4 which breaks CI (https://github.com/kemalcr/kemal/runs/6635872206).