### PR TITLE
content_for failing to capture the correct block input

### DIFF
--- a/spec/asset/hello_with_content_for.ecr
+++ b/spec/asset/hello_with_content_for.ecr
@@ -1,5 +1,5 @@
 Hello <%= name %>
 
-<% content_for "custom" do %>
-	<h1>Hello from otherside</h1>
+<% content_for "meta" do %>
+<title>Kemal Spec</title>
 <% end %>

--- a/spec/asset/layout_with_yield.ecr
+++ b/spec/asset/layout_with_yield.ecr
@@ -1,6 +1,8 @@
 <html>
+	<head>
+		<%= yield_content "meta" %>
+	</head>
 	<body>
 		<%= content %>
-		<%= yield_content "custom" %>
 	</body>
 </html>

--- a/spec/asset/layout_with_yield_and_vars.ecr
+++ b/spec/asset/layout_with_yield_and_vars.ecr
@@ -1,8 +1,10 @@
 <html>
+	<head>
+		<%= yield_content "meta" %>
+	</head>
 	<body>
 		<%= content %>
-		<%= yield_content "custom" %>
-    <%= var1 %>
-    <%= var2 %>
+    	<%= var1 %>
+    	<%= var2 %>
 	</body>
 </html>

--- a/spec/view_spec.cr
+++ b/spec/view_spec.cr
@@ -56,8 +56,8 @@ describe "Views" do
     end
     request = HTTP::Request.new("GET", "/view/world")
     client_response = call_request_on_app(request)
-    client_response.body.should contain("Hello world")
-    client_response.body.should contain("<h1>Hello from otherside</h1>")
+    client_response.body.scan("Hello world").size.should eq(1)
+    client_response.body.should contain("<title>Kemal Spec</title>")
   end
 
   it "does not render content_for that was not yielded" do

--- a/src/kemal/helpers/macros.cr
+++ b/src/kemal/helpers/macros.cr
@@ -43,7 +43,14 @@ macro yield_content(key)
   if CONTENT_FOR_BLOCKS.has_key?({{key}})
     __caller_filename__ = CONTENT_FOR_BLOCKS[{{key}}][0]
     %proc = CONTENT_FOR_BLOCKS[{{key}}][1]
-    %proc.call if __content_filename__ == __caller_filename__
+
+    if __content_filename__ == __caller_filename__
+      %old_content_io, content_io = content_io, IO::Memory.new
+      %proc.call
+      %result = content_io.to_s
+      content_io = %old_content_io
+      %result
+    end
   end
 end
 


### PR DESCRIPTION
Related to https://github.com/kemalcr/kemal/issues/636, I discovered that `content_for` is not capturing and yielding the correct block input inside the `ecr` view. It weirdly captures the whole content of the file

Take this for example:

`src/views/home.ecr`
```crystal
Hello <%= name %>

<% content_for "meta" do %>
<title>Kemal Spec</title>
<% end %>
```

`src/views/layout.ecr`
```crystal
<html>
	<head>
		<%= yield_content "meta" %>
	</head>
	<body>
		<%= content %>
	</body>
</html>
```

`src/kemal-bug.cr`
```crystal
require "kemal"

get "/" do
  render "src/views/home.ecr", "src/views/layout.ecr"
end

Kemal.run
```

When you go to `/` you'd expect the correct output with `<meta>` tag inside the `<head>` tag however this is the following output.

```
<html>
	<head>
		Hello world

               <title>Kemal Spec</title>
	</head>
	<body>
		Hello world
	</body>
</html>
```

the `Hello world` outside of the block in `src/views/home.ecr` is also captured by the `content_for` block and then yielded again which leads to **duplicate** content. For more info here's where it's yielded in the `content_for` macro
https://github.com/kemalcr/kemal/blob/master/src/kemal/helpers/macros.cr#L37

I think the wrong capture of the block might be a bug in Crystal itself in ECR, WDYT @straight-shoota?