### PR TITLE
Enable option for index.html to be a directories default

### DIFF
--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -23,6 +23,15 @@ describe Kemal::StaticFileHandler do
     response.body.should eq(File.read("#{__DIR__}/static/dir/test.txt"))
   end
 
+  it "should serve the 'index.html' file when a directory is requested and index serving is enabled" do
+    serve_static({"dir_index" => true})
+    response = handle HTTP::Request.new("GET", "/dir/")
+    response.status_code.should eq(200)
+    response.headers["Content-Type"].should eq "text/html"
+    response.headers["Etag"].should contain "W/\""
+    response.body.should eq(File.read("#{__DIR__}/static/dir/index.html"))
+  end
+
   it "should respond with 304 if file has not changed" do
     response = handle HTTP::Request.new("GET", "/dir/test.txt")
     response.status_code.should eq(200)

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -31,7 +31,7 @@ module Kemal
       @host_binding = "0.0.0.0"
       @port = 3000
       @env = ENV["KEMAL_ENV"]? || "development"
-      @serve_static = {"dir_listing" => false, "gzip" => true}
+      @serve_static = {"dir_listing" => false, "gzip" => true, "dir_index" => false}
       @public_folder = "./public"
       @logging = true
       @logger = nil


### PR DESCRIPTION
### Description of the Change

Sometimes (often?) when people serve static files, they may want "pretty urls" - e.g. "/welcome" vs "/welcome/index.html". This config option enables `index.html` to be the default if the request is for a folder and the file exists, otherwise it defaults to directory listing (if enabled).

### Alternate Designs

I considered just doing it in my app directly, but I belive this is a useful & missing minor feature.

### Benefits

Serving static html from pretty folders is now easy.

### Possible Drawbacks

Except for the additional code, none I can think of as it's disabled by default. I'm acutally not sure where to document this though.
