### PR TITLE
Closes response by default in HTTP::Server::Context#redirect

### DIFF
--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -143,4 +143,40 @@ describe "Kemal::RouteHandler" do
     client_response.body.should eq("Redirecting to /login")
     client_response.headers.has_key?("Location").should eq(true)
   end
+
+  it "redirects and closes response in before filter" do
+    filter_handler = Kemal::FilterHandler.new
+    filter_handler._add_route_filter("GET", "/", :before) do |env|
+      env.redirect "/login"
+    end
+    Kemal.config.add_filter_handler(filter_handler)
+
+    get "/" do |env|
+      "home page"
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(302)
+    client_response.body.should eq("")
+    client_response.headers.has_key?("Location").should eq(true)
+  end
+
+  it "redirects in before filter without closing response" do
+    filter_handler = Kemal::FilterHandler.new
+    filter_handler._add_route_filter("GET", "/", :before) do |env|
+      env.redirect "/login", close: false
+    end
+    Kemal.config.add_filter_handler(filter_handler)
+
+    get "/" do |env|
+      "home page"
+    end
+
+    request = HTTP::Request.new("GET", "/")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(302)
+    client_response.body.should eq("home page")
+    client_response.headers.has_key?("Location").should eq(true)
+  end
 end

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -17,10 +17,11 @@ class HTTP::Server
       @params ||= Kemal::ParamParser.new(@request, route_lookup.params)
     end
 
-    def redirect(url : String, status_code : Int32 = 302, *, body : String? = nil)
+    def redirect(url : String, status_code : Int32 = 302, *, body : String? = nil, close : Bool = true)
       @response.headers.add "Location", url
       @response.status_code = status_code
       @response.print(body) if body
+      @response.close if close
     end
 
     def route


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

Closes HTTP::Server::Response by default in HTTP::Server::Context#redirect

### Alternate Designs
Does not close response by default with option to override it.
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Redirections in before filters would skip processing in RouteHandler
<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks
Writing to closed HTTP::Server::Response raises `Closed stream (IO::Error)`
<!-- What are the possible side-effects or negative impacts of the code change? -->
