### PR TITLE
Bump `exception_page` shard to v0.3.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ dependencies:
     version: ~> 0.4.0
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.2.0
+    version: ~> 0.3.0
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
### Benefits

https://github.com/crystal-loot/exception_page/pull/33

### Possible Drawbacks

None?
