### PR TITLE
Omitting filters fix for lowercase methods requests - Take 2 

### DIFF
--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -1,0 +1,33 @@
+require "./spec_helper"
+
+describe "Kemal::FilterHandler" do
+  it "handles with upcased 'POST'" do
+    before_post do |env|
+      env.set "sensitive", "1"
+    end
+
+    post "/sensitive_post" do |env|
+      env.get "sensitive"
+    end
+
+    request = HTTP::Request.new("POST", "/sensitive_post")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(200)
+    client_response.body.should eq("1")
+  end
+
+  it "handles with downcased 'post'" do
+    before_post do |env|
+      env.set "sensitive", "1"
+    end
+
+    post "/sensitive_post" do |env|
+      "sensitive"
+    end
+
+    request = HTTP::Request.new("post", "/sensitive_post")
+    client_response = call_request_on_app(request)
+    client_response.status_code.should eq(200)
+    client_response.body.should eq("")
+  end
+end

--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -2,9 +2,11 @@ require "./spec_helper"
 
 describe "Kemal::FilterHandler" do
   it "handles with upcased 'POST'" do
-    before_post do |env|
+    filter_handler = Kemal::FilterHandler.new
+    filter_handler._add_route_filter("POST", "*", :before) do |env|
       env.set "sensitive", "1"
     end
+    Kemal.config.add_filter_handler(filter_handler)
 
     post "/sensitive_post" do |env|
       env.get "sensitive"
@@ -17,9 +19,11 @@ describe "Kemal::FilterHandler" do
   end
 
   it "handles with downcased 'post'" do
-    before_post do |env|
+    filter_handler = Kemal::FilterHandler.new
+    filter_handler._add_route_filter("POST", "*", :before) do |env|
       env.set "sensitive", "1"
     end
+    Kemal.config.add_filter_handler(filter_handler)
 
     post "/sensitive_post" do |env|
       "sensitive"

--- a/spec/filters_spec.cr
+++ b/spec/filters_spec.cr
@@ -25,7 +25,7 @@ describe "Kemal::FilterHandler" do
     end
     Kemal.config.add_filter_handler(filter_handler)
 
-    post "/sensitive_post" do |env|
+    post "/sensitive_post" do
       "sensitive"
     end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -85,6 +85,7 @@ end
 
 Spec.after_each do
   Kemal.config.clear
+  Kemal::FilterHandler::INSTANCE.tree = Radix::Tree(Array(Kemal::FilterHandler::FilterBlock)).new
   Kemal::RouteHandler::INSTANCE.routes = Radix::Tree(Route).new
   Kemal::RouteHandler::INSTANCE.cached_routes = Hash(String, Radix::Result(Route)).new
   Kemal::WebSocketHandler::INSTANCE.routes = Radix::Tree(WebSocket).new

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -3,6 +3,7 @@ module Kemal
   class FilterHandler
     include HTTP::Handler
     INSTANCE = new
+    property tree
 
     # This middleware is lazily instantiated and added to the handlers as soon as a call to `after_X` or `before_X` is made.
     def initialize

--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -11,19 +11,17 @@ module Kemal
 
     macro only(paths, method = "GET")
       class_name = {{@type.name}}
-      method_downcase = {{method.downcase}}
-      class_name_method = "#{class_name}/#{method_downcase}"
+      class_name_method = "#{class_name}/#{{{method}}}"
       ({{paths}}).each do |path|
-        @@only_routes_tree.add class_name_method + path, '/' + method_downcase + path
+        @@only_routes_tree.add class_name_method + path, '/' + {{method}} + path
       end
     end
 
     macro exclude(paths, method = "GET")
       class_name = {{@type.name}}
-      method_downcase = {{method.downcase}}
-      class_name_method = "#{class_name}/#{method_downcase}"
+      class_name_method = "#{class_name}/#{{{method}}}"
       ({{paths}}).each do |path|
-        @@exclude_routes_tree.add class_name_method + path, '/' + method_downcase + path
+        @@exclude_routes_tree.add class_name_method + path, '/' + {{method}} + path
       end
     end
 
@@ -74,7 +72,7 @@ module Kemal
     end
 
     private def radix_path(method : String, path : String)
-      "#{self.class}/#{method.downcase}#{path}"
+      "#{self.class}/#{method}#{path}"
     end
   end
 end

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -57,7 +57,7 @@ module Kemal
     end
 
     private def radix_path(method, path)
-      '/' + method.downcase + path
+      '/' + method + path
     end
 
     private def add_to_radix_tree(method, path, route)


### PR DESCRIPTION
Follow up on #564 according to @straight-shoota comment this treats `post` method as a new route.

I'm not sure why the `filters_spec` fail when ran with all the specs. It passes on its' own.