### PR TITLE
Allow HTTP::Server::Context#redirect to take an URL

### DIFF
--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -17,8 +17,8 @@ class HTTP::Server
       @params ||= Kemal::ParamParser.new(@request, route_lookup.params)
     end
 
-    def redirect(url : String, status_code : Int32 = 302, *, body : String? = nil, close : Bool = true)
-      @response.headers.add "Location", url
+    def redirect(url : String | URI, status_code : Int32 = 302, *, body : String? = nil, close : Bool = true)
+      @response.headers.add "Location", url.to_s
       @response.status_code = status_code
       @response.print(body) if body
       @response.close if close


### PR DESCRIPTION
### Description of the Change

Had a bit of a `huh?` moment when I discovered that I can't redirect to an URI, but it has to be a string. So I thought `#redirect` might as well take a `String | URI`.

### Alternate Designs

Could've made an overload, but this looks nicer. Think the compiler will optimize it in any case.

### Benefits

Usage looks nicer.

### Possible Drawbacks

Possibly a miniscule performance impact, in theory something has to check whether it's a string or URI now, but I believe the compiler is smarter than that.
