### PR TITLE
Move to Process.on_interupt

### DIFF
--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -89,10 +89,10 @@ module Kemal
   end
 
   private def self.setup_trap_signal
-    Process.on_interrupt {
+    Process.on_interrupt do
       log "#{Kemal.config.app_name} is going to take a rest!" if Kemal.config.shutdown_message
       Kemal.stop
       exit
-    }
+    end
   end
 end

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -89,10 +89,10 @@ module Kemal
   end
 
   private def self.setup_trap_signal
-    Signal::INT.trap do
+    Process.on_interrupt {
       log "#{Kemal.config.app_name} is going to take a rest!" if Kemal.config.shutdown_message
       Kemal.stop
       exit
-    end
+    }
   end
 end


### PR DESCRIPTION
I remember this change was implemented before, I see that it is reverted now and I want that change back because developers on Windows are complaining that it broke their builds.

### Description of the Change

Switches to a platform agnostic interrupt handler.

### Benefits

Windows support

### Possible Drawbacks

None