### PR TITLE
Bump `exception_page` dependency

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ dependencies:
     version: ~> 0.4.0
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.3.0
+    version: ~> 0.4.0
 
 development_dependencies:
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ dependencies:
     version: ~> 0.4.0
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.4.0
+    version: ~> 0.4.1
 
 development_dependencies:
   ameba:

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -38,7 +38,7 @@ describe "Kemal::WebSocketHandler" do
 
   it "fetches named url parameters" do
     handler = Kemal::WebSocketHandler::INSTANCE
-    ws "/:id" { |_, c| c.ws_route_lookup.params["id"] }
+    ws "/:id" { |_, context| context.ws_route_lookup.params["id"] }
     headers = HTTP::Headers{
       "Upgrade"               => "websocket",
       "Connection"            => "Upgrade",

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -159,8 +159,8 @@ module Kemal
     end
 
     private def setup_filter_handlers
-      FILTER_HANDLERS.each do |h|
-        HANDLERS.insert(@handler_position, h)
+      FILTER_HANDLERS.each do |handler|
+        HANDLERS.insert(@handler_position, handler)
       end
     end
   end

--- a/src/kemal/ext/context.cr
+++ b/src/kemal/ext/context.cr
@@ -9,7 +9,7 @@ class HTTP::Server
     STORE_MAPPINGS = [Nil, String, Int32, Int64, Float64, Bool]
 
     macro finished
-      alias StoreTypes = Union({{ *STORE_MAPPINGS }})
+      alias StoreTypes = Union({{ STORE_MAPPINGS.splat }})
       @store = {} of String => StoreTypes
     end
 


### PR DESCRIPTION
### Description of the Change

- Bumps `exception_page` shard version to `~> 0.4.1`, which includes syntax highlighting and tweaked UX.
- Fixes Ameba issues, which makes CI 💚 again
- Fixes Crystal deprecation warning