### PR TITLE
Directory Listing: Add UTF-8 Charset to the response Content type

### DIFF
--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -57,7 +57,7 @@ module Kemal
           end
           send_file(context, file_path)
         elsif config.is_a?(Hash) && config.fetch("dir_listing", false)
-          context.response.content_type = "text/html"
+          context.response.content_type = "text/html;charset=UTF-8;"
           directory_listing(context.response, request_path, file_path)
         else
           call_next(context)


### PR DESCRIPTION
Within the directory listing handler, the absence of an explicit charset in the content type has led to issues, particularly with directories containing non-ASCII symbols, resulting in broken displays.

<img width="429" alt="изображение" src="https://github.com/kemalcr/kemal/assets/860357/42572e2c-db4c-43b9-9064-7790ec8ec778">

Adding charset charset=UTF-8 to the Content-type header fixes this issue.

<img width="429" alt="изображение" src="https://github.com/kemalcr/kemal/assets/860357/fecff866-90fc-40b9-9b94-8f114f2c6dcb">


### Alternate Designs

 - Add `<meta charset="UTF-8">` to https://github.com/crystal-lang/crystal/blob/master/src/http/server/handlers/static_file_handler.html 
 - Add charset as an optional parameter to `serve_static` config

### Benefits

it works

### Possible Drawbacks

Not flexible for non UTF-8 cases. 
