### PR TITLE
clarify startup message in test mode

### DIFF
--- a/spec/run_spec.cr
+++ b/spec/run_spec.cr
@@ -26,7 +26,7 @@ describe "Run" do
   end
 
   it "runs without a block being specified" do
-    run(<<-CR).should eq "[test] Kemal is ready to lead at http://0.0.0.0:3000\ntrue\n"
+    run(<<-CR).should contain "[test] Kemal is running in test mode."
       Kemal.config.env = "test"
       Kemal.run
       puts Kemal.config.running
@@ -34,7 +34,7 @@ describe "Run" do
   end
 
   it "allows custom HTTP::Server bind" do
-    run(<<-CR).should eq "[test] Kemal is ready to lead at http://127.0.0.1:3000, http://0.0.0.0:3001\n"
+    run(<<-CR).should contain "[test] Kemal is running in test mode."
       Kemal.config.env = "test"
       Kemal.run do |config|
         server = config.server.not_nil!

--- a/src/kemal.cr
+++ b/src/kemal.cr
@@ -66,8 +66,12 @@ module Kemal
   end
 
   def self.display_startup_message(config, server)
-    addresses = server.addresses.join ", " { |address| "#{config.scheme}://#{address}" }
-    log "[#{config.env}] #{config.app_name} is ready to lead at #{addresses}"
+    if config.env != "test"
+      addresses = server.addresses.join ", " { |address| "#{config.scheme}://#{address}" }
+      log "[#{config.env}] #{config.app_name} is ready to lead at #{addresses}"
+    else
+      log "[#{config.env}] #{config.app_name} is running in test mode. Server not listening"
+    end
   end
 
   def self.stop


### PR DESCRIPTION
Before this PR. When I started kemal in test mode. It would say that the app is ready and listening at xyz address. However. Kemal's server does not start when in test mode so that statement is incorrect - See last line in `Kemal.run`