### PR TITLE
Add ability to add handlers for raised exceptions

### DIFF
--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -26,6 +26,9 @@ class AnotherContextStorageType
   @name = "kemal-context"
 end
 
+class CustomExceptionType < Exception
+end
+
 add_context_storage_type(TestContextStorageType)
 add_context_storage_type(AnotherContextStorageType)
 

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -12,7 +12,7 @@ module Kemal
     HANDLERS        = [] of HTTP::Handler
     CUSTOM_HANDLERS = [] of Tuple(Nil | Int32, HTTP::Handler)
     FILTER_HANDLERS = [] of HTTP::Handler
-    ERROR_HANDLERS  = {} of Int32 => HTTP::Server::Context, Exception -> String
+    ERROR_HANDLERS = {} of (Int32 | Exception.class) => HTTP::Server::Context, Exception -> String
 
     {% if flag?(:without_openssl) %}
       @ssl : Bool?
@@ -94,6 +94,10 @@ module Kemal
 
     def add_error_handler(status_code : Int32, &handler : HTTP::Server::Context, Exception -> _)
       ERROR_HANDLERS[status_code] = ->(context : HTTP::Server::Context, error : Exception) { handler.call(context, error).to_s }
+    end
+
+    def add_error_handler(exception : Exception.class, &handler : HTTP::Server::Context, Exception -> _)
+      ERROR_HANDLERS[exception] = ->(context : HTTP::Server::Context, error : Exception) { handler.call(context, error).to_s }
     end
 
     def extra_options(&@extra_options : OptionParser ->)

--- a/src/kemal/dsl.cr
+++ b/src/kemal/dsl.cr
@@ -25,6 +25,11 @@ def error(status_code : Int32, &block : HTTP::Server::Context, Exception -> _)
   Kemal.config.add_error_handler status_code, &block
 end
 
+# Defines an error handler to be called when the given exception is raised
+def error(exception : Exception.class, &block : HTTP::Server::Context, Exception -> _)
+  Kemal.config.add_error_handler exception, &block
+end
+
 # All the helper methods available are:
 #  - before_all, before_get, before_post, before_put, before_patch, before_delete, before_options
 #  - after_all, after_get, after_post, after_put, after_patch, after_delete, after_options

--- a/src/kemal/exception_handler.cr
+++ b/src/kemal/exception_handler.cr
@@ -11,10 +11,24 @@ module Kemal
     rescue ex : Kemal::Exceptions::CustomException
       call_exception_with_status_code(context, ex, context.response.status_code)
     rescue ex : Exception
+      # Use error handler defined for the current exception if it exists
+      return call_exception_with_exception(context, ex, 500) if Kemal.config.error_handlers.has_key?(ex.class)
       log("Exception: #{ex.inspect_with_backtrace}")
+      # Else use generic 500 handler if defined
       return call_exception_with_status_code(context, ex, 500) if Kemal.config.error_handlers.has_key?(500)
       verbosity = Kemal.config.env == "production" ? false : true
       render_500(context, ex, verbosity)
+    end
+
+    private def call_exception_with_exception(context : HTTP::Server::Context, exception : Exception, status_code : Int32 = 500)
+      return if context.response.closed?
+
+      if !Kemal.config.error_handlers.empty? && Kemal.config.error_handlers.has_key?(exception.class)
+        context.response.content_type = "text/html" unless context.response.headers.has_key?("Content-Type")
+        context.response.status_code = status_code
+        context.response.print Kemal.config.error_handlers[exception.class].call(context, exception)
+        context
+      end
     end
 
     private def call_exception_with_status_code(context : HTTP::Server::Context, exception : Exception, status_code : Int32)


### PR DESCRIPTION
Closes #622

### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

This PR adds the ability for users to define error handlers that are used when a specific exception is raised. 
```crystal
require "kemal"

class NewException < Exception
end

get "/" do | env |
  raise NewException.new()
end

error NewException do | env |
  "An error occured!"
end

Kemal.run

```

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

This provides for a cleaner and easier experience for defining custom errors.  See #622.


### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->
