### PR TITLE
`crystal tool format` with Crystal 1.15.0-dev

### DIFF
--- a/spec/init_handler_spec.cr
+++ b/spec/init_handler_spec.cr
@@ -6,7 +6,7 @@ describe "Kemal::InitHandler" do
     io = IO::Memory.new
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
-    Kemal::InitHandler::INSTANCE.next = ->(_context : HTTP::Server::Context) {}
+    Kemal::InitHandler::INSTANCE.next = ->(_context : HTTP::Server::Context) { }
     Kemal::InitHandler::INSTANCE.call(context)
     context.response.headers["Content-Type"].should eq "text/html"
   end
@@ -16,7 +16,7 @@ describe "Kemal::InitHandler" do
     io = IO::Memory.new
     response = HTTP::Server::Response.new(io)
     context = HTTP::Server::Context.new(request, response)
-    Kemal::InitHandler::INSTANCE.next = ->(_context : HTTP::Server::Context) {}
+    Kemal::InitHandler::INSTANCE.next = ->(_context : HTTP::Server::Context) { }
     Kemal::InitHandler::INSTANCE.call(context)
     date = context.response.headers["Date"]?.should_not be_nil
     date = HTTP.parse_time(date).should_not be_nil


### PR DESCRIPTION
Crystal nightly has a couple new formatter rules enabled: https://github.com/crystal-lang/crystal/pull/14718
The changes are backwards-compatible, so Crystal 1.14.0 won't complain about the new format.