### PR TITLE
Add support for multiple file uploads for params.files

### DIFF
--- a/src/kemal/param_parser.cr
+++ b/src/kemal/param_parser.cr
@@ -15,7 +15,7 @@ module Kemal
       @query = HTTP::Params.new({} of String => Array(String))
       @body = HTTP::Params.new({} of String => Array(String))
       @json = {} of String => AllParamTypes
-      @files = {} of String => FileUpload
+      @files = {} of String => Array(FileUpload)
       @url_parsed = false
       @query_parsed = false
       @body_parsed = false
@@ -71,11 +71,13 @@ module Kemal
         next unless upload
 
         filename = upload.filename
+        name = upload.name
 
         if !filename.nil?
-          @files[upload.name] = FileUpload.new(upload)
+          @files[name] ||= [] of FileUpload
+          @files[name] << FileUpload.new(upload)
         else
-          @body.add(upload.name, upload.body.gets_to_end)
+          @body.add(name, upload.body.gets_to_end)
         end
       end
 


### PR DESCRIPTION
### Description of the Change

Currently you can't have an array of files for the given name.
This PR adds support for multiple file uploads for `params.files`

### Benefits

Users can now access multiple file uploads with the given name in `params.files`

```crystal
images = env.params.files["images[]"]?

# Loop through images and save each
if images
  images.each do |image|
    unless image.filename.not_nil!.empty?
      file = image.tempfile

      File.open(file_path, "w") do |f|
        f.write(file.gets_to_end.to_slice)
      end
    end
  end
end
```

### Possible Drawbacks

This will break all the existing code as `env.params.files["images[]"]` was only returning a single file upload.
Users will now need to use `env.params.files["images[]"][0]` to have the same behavior.