### PR TITLE
Return after `redirect_to`

### DIFF
--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -40,8 +40,10 @@ module Kemal
 
       if request_path != expanded_path
         redirect_to context, expanded_path
+        return
       elsif is_dir && !is_dir_path
         redirect_to context, expanded_path + '/'
+        return
       end
 
       if is_dir


### PR DESCRIPTION
### Description of the Change

This PR adds `return` statements after uses of `redirect_to` to halt further processing. This follows the pattern in the standard library [here](https://github.com/crystal-lang/crystal/blob/master/src/http/server/handlers/static_file_handler.cr#L80) and eliminates spurious stack traces in the output in some circumstances.

Given a simple Kemal application (tmp.cr) like the following that installs a handler that modifies the response:
```
require "kemal"

class MyHandler < Kemal::Handler
  def call(context)
    context.response.content_type = "application/json"
    call_next context
  end
end

add_handler MyHandler.new

get "/" do
end

Kemal.run
```

And a public directory with a single sub-directory to trigger the static file handler:
```
public/
  tmp/
```

A request like the following against the running application results in a stack trace in the output:
```
curl localhost:3000/tmp
```

```
Exception: Closed stream (IO::Error)
  from src/http/server/response.cr:203:7 in 'check_headers'
  from src/http/server/response.cr:72:7 in 'content_type='
  from tmp.cr:5:5 in 'call'
  from src/http/server/handler.cr:30:7 in 'call_next'
  ...
```

The static file handler sets up the redirect and closes the response (via `redirect_to`) but then allows handler processing to proceed.

### Alternate Designs

It is possible to work around this by modifying `MyHandler` to check to see if the handler is closed, and that was my first solution. But I now believe the current implementation without the `return`s is a bug and pushing this solution upstream is a better alternative.

### Benefits

Removes a spurious stack trace in some circumstances.

### Possible Drawbacks

There are none that I am aware of. I have been running a patched version of Kemal for several day in production.