### PR TITLE
Use ameba github actions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,27 +30,6 @@ jobs:
       - name: Run specs
         run: |
           crystal spec
-
-  format:
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        crystal: [latest, nightly]
-    runs-on: ${{ matrix.os }}
-
-    steps:
-      - name: Install Crystal
-        uses: crystal-lang/install-crystal@v1
-        with:
-          crystal: ${{ matrix.crystal }}
-
-      - name: Download source
-        uses: actions/checkout@v4
-
-      - name: Check formatting
-        run: crystal tool format --check
-    
   ameba:
     strategy:
       fail-fast: false
@@ -68,9 +47,7 @@ jobs:
       - name: Download source
         uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: shards install
-
-      - name: Run ameba linter
-        run: bin/ameba
-        
+      - name: Crystal Ameba Linter
+        uses: crystal-ameba/github-action@v0.12.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Replace `format` and `ameba` jobs by a github action.

Ameba already check the code format and the github action comments on PRs, that's better than dig the errors in github actions page.

### Alternate Designs

Change nothing 😅.

### Benefits

See linter errors directly on github PRs as comments.

### Possible Drawbacks

None.
