### PR TITLE
Remove ameba developer dependency 🔥 

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -12,10 +12,6 @@ dependencies:
     github: crystal-loot/exception_page
     version: ~> 0.5.0
 
-development_dependencies:
-  ameba:
-    github: crystal-ameba/ameba
-
 crystal: ">= 0.36.0"
 
 license: MIT


### PR DESCRIPTION
### Description of the Change

Since d4af7e216daa22111a6f906cbcdde280646ba9bf added ameba as a github action, there's no need to include ameba as developer dependency, people that still want to run ameba locally can just install it in their system.

This would remove the post-install in kemal and make some guys happy at https://forum.crystal-lang.org/t/shards-postinstall-considered-harmful/3910

### Alternate Designs

Keep everything as is.

### Benefits

No post-install when using kemal.

### Possible Drawbacks

Need to install ameba manually if want to run it locally.
