### PR TITLE
Add before_all filter execution for 404 error in FilterHandler

### DIFF
--- a/spec/middleware/filters_spec.cr
+++ b/spec/middleware/filters_spec.cr
@@ -207,6 +207,22 @@ describe "Kemal::FilterHandler" do
     client_response = HTTP::Client::Response.from_io(io_with_context, decompress: false)
     client_response.body.should eq("true-true")
   end
+
+  it "executes before_all filter on 404" do
+    before_filter = FilterTest.new
+    before_filter.modified = "false"
+
+    filter_middleware = Kemal::FilterHandler.new
+    filter_middleware._add_route_filter("ALL", "*", :before) { before_filter.modified = "true" }
+
+    error 404 do
+      before_filter.modified
+    end
+
+    request = HTTP::Request.new("GET", "/not_found")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("true")
+  end
 end
 
 class FilterTest

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -13,7 +13,13 @@ module Kemal
 
     # The call order of the filters is `before_all -> before_x -> X -> after_x -> after_all`.
     def call(context : HTTP::Server::Context)
-      return call_next(context) unless context.route_found?
+      if !context.route_found?
+        if Kemal.config.error_handlers.has_key?(404)
+          call_block_for_path_type("ALL", context.request.path, :before, context)
+        end
+        return call_next(context)
+      end
+
       call_block_for_path_type("ALL", context.request.path, :before, context)
       call_block_for_path_type(context.request.method, context.request.path, :before, context)
       if Kemal.config.error_handlers.has_key?(context.response.status_code)


### PR DESCRIPTION
This change modifies the FilterHandler to execute before_all filters when a 404 error occurs. A new test case has been added to verify that the before_all filter is triggered correctly for non-existent routes.

Implements #663