### PR TITLE
Add support for custom log messages in Kemal::RequestLogHandler

### DIFF
--- a/spec/request_log_handler_spec.cr
+++ b/spec/request_log_handler_spec.cr
@@ -14,4 +14,20 @@ describe Kemal::RequestLogHandler do
       logs.check(:info, /404 GET \/ \d+.*s/)
     end
   end
+
+  it "allows custom log message format" do
+    Log.setup(:none)
+
+    request = HTTP::Request.new("GET", "/")
+    response = HTTP::Server::Response.new(IO::Memory.new)
+    context = HTTP::Server::Context.new(request, response)
+    request_logger = Kemal::RequestLogger.new do |ctx, elapsed_time|
+      "#{ctx.request.method} custom log line #{elapsed_time}"
+    end
+    logger = Kemal::RequestLogHandler.new(request_logger)
+    Log.capture do |logs|
+      logger.call(context)
+      logs.check(:info, /GET custom log line \d+.*s/)
+    end
+  end
 end

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -60,6 +60,19 @@ module Kemal
       @logger = logger
     end
 
+    # The request logger is used to log custom messages for each request.
+    #
+    # It's a proc that receives the request context and the elapsed time (as
+    # String, e.g. "2.5ms") for the request and returns the string to be
+    # logged.
+    def request_logger=(request_logger : RequestLogger)
+      if @logger
+        raise "Request logger can't be set on custom loggers or after Kemal started."
+      end
+
+      @logger = Kemal::RequestLogHandler.new(request_logger)
+    end
+
     def scheme
       ssl ? "https" : "http"
     end

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -35,7 +35,7 @@ end
 @[Deprecated("Use standard library Log")]
 def log(message : String)
   logger = Kemal.config.logger?
-  if logger
+  if logger.is_a?(Kemal::BaseLogHandler)
     logger.write "#{message}\n"
   else
     Log.info { message }


### PR DESCRIPTION
Add `Kemal::Config#request_logger=` to allow the user to set custom request log messages so users doesn't need to create a new HTTP handler when they just want to e.g. log in JSON format.

### Description of the Change

Currently, to change what's logged into every request a Kemal user must create its own HTTP::Handler and insert it into Kemal handlers chain. Not a complex task but a very verbose one.

This changes adds `Config#request_logger=`, to set a proc that will be used by Kemal::RequestLogHandler.

### Alternate Designs

I didn't think much about this, comments are welcome.

### Benefits

No need to write a HTTP::Handler just to have a different log message for requests.

### Possible Drawbacks

An extra function call on every request being logged.
