### PR TITLE
Move `Kemal::Handler` logic into separate module

### DIFF
--- a/src/kemal/handler.cr
+++ b/src/kemal/handler.cr
@@ -1,13 +1,20 @@
 module Kemal
-  # `Kemal::Handler` is a subclass of `HTTP::Handler`.
+  # Kemal::HandlerInterface provides helpful methods for use in middleware creation
   #
-  # It adds `only`, `only_match?`, `exclude`, `exclude_match?`.
-  # These methods are useful for the conditional execution of custom handlers .
-  class Handler
+  # More specifically, `only`, `only_match?`, `exclude`, `exclude_match?`
+  # allows one to define the conditional execution of custom handlers.
+  #
+  # To use, simply `include` it within your type.
+  #
+  # It is an implementation of `HTTP::Handler` and can be used anywhere that
+  # requests an `HTTP::Handler` type.
+  module HandlerInterface
     include HTTP::Handler
 
-    @@only_routes_tree = Radix::Tree(String).new
-    @@exclude_routes_tree = Radix::Tree(String).new
+    macro included
+      @@only_routes_tree = Radix::Tree(String).new
+      @@exclude_routes_tree = Radix::Tree(String).new
+    end
 
     macro only(paths, method = "GET")
       class_name = {{@type.name}}
@@ -74,5 +81,14 @@ module Kemal
     private def radix_path(method : String, path : String)
       "#{self.class}/#{method}#{path}"
     end
+  end
+
+  # `Kemal::Handler` is an implementation of `HTTP::Handler`.
+  #
+  # It includes `HandlerInterface` to add the methods
+  # `only`, `only_match?`, `exclude`, `exclude_match?`.
+  # These methods are useful for the conditional execution of custom handlers .
+  class Handler
+    include HandlerInterface
   end
 end


### PR DESCRIPTION
### Description of the Change

<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts. -->

This PR moves the logic for `Kemal::Handler` into a separate module and then makes the class include it.

Like `HTTP::Handler` prior to being made a module `Kemal::Handler` is pretty much an interface already. It isn't intended to be initialized directly and really just serves to provide helper methods for any children class that inherits from it.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

This grants the application the additional freedom to inherit from different classes while still retaining the methods provided by `Kemal::Handler`.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

There shouldn't be any and everything should also be fully backwards compatible too. `Kemal::Handler` includes the new module and gets its class vars defined by an `included` macro from the module so the behavior is the same.