### PR TITLE
Add in-memory static file caching to StaticFileHandler

### DIFF
--- a/spec/config_spec.cr
+++ b/spec/config_spec.cr
@@ -69,4 +69,16 @@ describe "Config" do
     config.app_name = "testapp"
     config.app_name.should eq "testapp"
   end
+
+  it "preserves explicit zero static size options" do
+    config = Kemal::Config.new
+    config.serve_static = {"cache_size" => 0, "cache_check_interval" => 0}
+
+    config.serve_static_size_option?("cache_size").should eq(0)
+    config.serve_static_size_option?("cache_check_interval").should eq(0)
+  end
+
+  it "returns nil for missing static size options" do
+    Kemal::Config.new.serve_static_size_option?("cache_size").should be_nil
+  end
 end

--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -339,12 +339,13 @@ describe "Macros" do
     end
 
     it "should accept cache options" do
-      serve_static({"cache" => true, "cache_size" => 1024})
+      serve_static({"cache" => true, "cache_size" => 1024, "cache_check_interval" => 250})
       conf = Kemal.config.serve_static
       conf.is_a?(Hash).should be_true
       if conf.is_a?(Hash)
         conf["cache"].should be_true
         conf["cache_size"].should eq(1024)
+        conf["cache_check_interval"].should eq(250)
       end
     end
   end

--- a/spec/helpers_spec.cr
+++ b/spec/helpers_spec.cr
@@ -337,5 +337,15 @@ describe "Macros" do
         conf["dir_listing"].should be_true
       end
     end
+
+    it "should accept cache options" do
+      serve_static({"cache" => true, "cache_size" => 1024})
+      conf = Kemal.config.serve_static
+      conf.is_a?(Hash).should be_true
+      if conf.is_a?(Hash)
+        conf["cache"].should be_true
+        conf["cache_size"].should eq(1024)
+      end
+    end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -54,9 +54,7 @@ def create_ws_request_and_return_io_and_context(handler, request)
   rescue IO::Error
     # Raises because the IO::Memory is empty
   end
-  {% if compare_versions(Crystal::VERSION, "0.35.0-0") >= 0 %}
-    response.upgrade_handler.try &.call(io)
-  {% end %}
+  response.upgrade_handler.try &.call(io)
   io.rewind
   {io, context}
 end

--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -1,10 +1,10 @@
 require "./spec_helper"
 
-private def handle(request, fallthrough = true, decompress = true, public_dir = "#{__DIR__}/static")
+private def handle(request, fallthrough = true, decompress = true, public_dir = "#{__DIR__}/static", handler : Kemal::StaticFileHandler? = nil)
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
-  handler = Kemal::StaticFileHandler.new public_dir, fallthrough
+  handler ||= Kemal::StaticFileHandler.new public_dir, fallthrough
   handler.call context
   response.close
   io.rewind
@@ -150,24 +150,57 @@ describe Kemal::StaticFileHandler do
   end
 
   it "should invalidate cached files when the source file changes" do
-    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024})
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024, "cache_check_interval" => 10})
     temp_dir = File.tempname("kemal-static-cache")
     Dir.mkdir(temp_dir)
 
     begin
+      handler = Kemal::StaticFileHandler.new temp_dir
       file_path = File.join(temp_dir, "test.txt")
       File.write(file_path, "first version")
 
-      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
       response.status_code.should eq(200)
       response.body.should eq("first version")
 
-      sleep 1.second
       File.write(file_path, "second version")
 
-      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir
+      sleep 20.milliseconds
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
       response.status_code.should eq(200)
       response.body.should eq("second version")
+    ensure
+      File.delete?(File.join(temp_dir, "test.txt"))
+      Dir.delete(temp_dir)
+    end
+  end
+
+  it "should defer metadata revalidation until the interval elapses" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024, "cache_check_interval" => 50})
+    temp_dir = File.tempname("kemal-static-cache-window")
+    Dir.mkdir(temp_dir)
+
+    begin
+      handler = Kemal::StaticFileHandler.new temp_dir
+      file_path = File.join(temp_dir, "test.txt")
+      File.write(file_path, "first version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+      response.body.should eq("first version")
+
+      File.write(file_path, "second version now")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+      response.body.should eq("first version")
+
+      sleep 60.milliseconds
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+      response.body.should eq("second version now")
     ensure
       File.delete?(File.join(temp_dir, "test.txt"))
       Dir.delete(temp_dir)

--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -149,6 +149,58 @@ describe Kemal::StaticFileHandler do
     response.body.should eq(File.read("#{__DIR__}/static/dir/test.txt")[0, 5])
   end
 
+  it "should revalidate cached files before honoring If-None-Match" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024, "cache_check_interval" => 5_000})
+    temp_dir = File.tempname("kemal-static-cache-etag")
+    Dir.mkdir(temp_dir)
+
+    begin
+      handler = Kemal::StaticFileHandler.new temp_dir
+      file_path = File.join(temp_dir, "test.txt")
+      File.write(file_path, "first version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      etag = response.headers["Etag"]
+
+      File.write(file_path, "second version")
+      sleep 20.milliseconds
+
+      headers = HTTP::Headers{"If-None-Match" => etag}
+      response = handle HTTP::Request.new("GET", "/test.txt", headers), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+      response.body.should eq("second version")
+    ensure
+      File.delete?(File.join(temp_dir, "test.txt"))
+      Dir.delete(temp_dir)
+    end
+  end
+
+  it "should honor If-Modified-Since for cached files" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024, "cache_check_interval" => 5_000})
+    handler = Kemal::StaticFileHandler.new "#{__DIR__}/static"
+
+    response = handle HTTP::Request.new("GET", "/dir/test.txt"), handler: handler
+    last_modified = response.headers["Last-Modified"]
+
+    headers = HTTP::Headers{"If-Modified-Since" => last_modified}
+    response = handle HTTP::Request.new("GET", "/dir/test.txt", headers), handler: handler
+    response.status_code.should eq(304)
+    response.body.should eq("")
+  end
+
+  it "should match uncached HEAD responses when served from the in-memory cache" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024})
+    handler = Kemal::StaticFileHandler.new "#{__DIR__}/static"
+
+    expected = handle HTTP::Request.new("HEAD", "/dir/test.txt")
+    handle HTTP::Request.new("GET", "/dir/test.txt"), handler: handler
+    response = handle HTTP::Request.new("HEAD", "/dir/test.txt"), handler: handler
+
+    response.status_code.should eq(expected.status_code)
+    response.headers["Content-Type"].should eq(expected.headers["Content-Type"])
+    response.body.should eq(expected.body)
+  end
+
   it "should invalidate cached files when the source file changes" do
     serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024, "cache_check_interval" => 10})
     temp_dir = File.tempname("kemal-static-cache")
@@ -170,6 +222,29 @@ describe Kemal::StaticFileHandler do
       response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
       response.status_code.should eq(200)
       response.body.should eq("second version")
+    ensure
+      File.delete?(File.join(temp_dir, "test.txt"))
+      Dir.delete(temp_dir)
+    end
+  end
+
+  it "should return 404 after a cached file is deleted and revalidated" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024, "cache_check_interval" => 0})
+    temp_dir = File.tempname("kemal-static-cache-delete")
+    Dir.mkdir(temp_dir)
+
+    begin
+      handler = Kemal::StaticFileHandler.new temp_dir
+      file_path = File.join(temp_dir, "test.txt")
+      File.write(file_path, "first version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+
+      File.delete(file_path)
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(404)
     ensure
       File.delete?(File.join(temp_dir, "test.txt"))
       Dir.delete(temp_dir)
@@ -203,6 +278,62 @@ describe Kemal::StaticFileHandler do
       response.body.should eq("second version now")
     ensure
       File.delete?(File.join(temp_dir, "test.txt"))
+      Dir.delete(temp_dir)
+    end
+  end
+
+  it "should not cache files larger than cache_size" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 4, "cache_check_interval" => 5_000})
+    temp_dir = File.tempname("kemal-static-cache-oversize")
+    Dir.mkdir(temp_dir)
+
+    begin
+      handler = Kemal::StaticFileHandler.new temp_dir
+      file_path = File.join(temp_dir, "test.txt")
+      File.write(file_path, "first version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+      response.body.should eq("first version")
+
+      File.write(file_path, "second version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir, handler: handler
+      response.status_code.should eq(200)
+      response.body.should eq("second version")
+    ensure
+      File.delete?(File.join(temp_dir, "test.txt"))
+      Dir.delete(temp_dir)
+    end
+  end
+
+  it "should leave newer files uncached when the cache budget is full" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 12, "cache_check_interval" => 5_000})
+    temp_dir = File.tempname("kemal-static-cache-budget")
+    Dir.mkdir(temp_dir)
+
+    begin
+      handler = Kemal::StaticFileHandler.new temp_dir
+      first_path = File.join(temp_dir, "first.txt")
+      second_path = File.join(temp_dir, "second.txt")
+      File.write(first_path, "first-one")
+      File.write(second_path, "second-a")
+
+      response = handle HTTP::Request.new("GET", "/first.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("first-one")
+      response = handle HTTP::Request.new("GET", "/second.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("second-a")
+
+      File.write(first_path, "first-two")
+      File.write(second_path, "second-b")
+
+      response = handle HTTP::Request.new("GET", "/first.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("first-one")
+      response = handle HTTP::Request.new("GET", "/second.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("second-b")
+    ensure
+      File.delete?(File.join(temp_dir, "first.txt"))
+      File.delete?(File.join(temp_dir, "second.txt"))
       Dir.delete(temp_dir)
     end
   end

--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -1,10 +1,10 @@
 require "./spec_helper"
 
-private def handle(request, fallthrough = true, decompress = true)
+private def handle(request, fallthrough = true, decompress = true, public_dir = "#{__DIR__}/static")
   io = IO::Memory.new
   response = HTTP::Server::Response.new(io)
   context = HTTP::Server::Context.new(request, response)
-  handler = Kemal::StaticFileHandler.new "#{__DIR__}/static", fallthrough
+  handler = Kemal::StaticFileHandler.new public_dir, fallthrough
   handler.call context
   response.close
   io.rewind
@@ -139,6 +139,41 @@ describe Kemal::StaticFileHandler do
     end
   end
 
+  it "should serve byte ranges from the in-memory cache" do
+    serve_static({"gzip" => false, "dir_listing" => true, "cache" => true, "cache_size" => 1024})
+    headers = HTTP::Headers{"Range" => "bytes=0-4"}
+    response = handle HTTP::Request.new("GET", "/dir/test.txt", headers)
+
+    response.status_code.should eq(206)
+    response.headers["Content-Range"].should eq("bytes 0-4/#{file_size}")
+    response.body.should eq(File.read("#{__DIR__}/static/dir/test.txt")[0, 5])
+  end
+
+  it "should invalidate cached files when the source file changes" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 1024})
+    temp_dir = File.tempname("kemal-static-cache")
+    Dir.mkdir(temp_dir)
+
+    begin
+      file_path = File.join(temp_dir, "test.txt")
+      File.write(file_path, "first version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir
+      response.status_code.should eq(200)
+      response.body.should eq("first version")
+
+      sleep 1.second
+      File.write(file_path, "second version")
+
+      response = handle HTTP::Request.new("GET", "/test.txt"), public_dir: temp_dir
+      response.status_code.should eq(200)
+      response.body.should eq("second version")
+    ensure
+      File.delete?(File.join(temp_dir, "test.txt"))
+      Dir.delete(temp_dir)
+    end
+  end
+
   it "should handle setting custom headers" do
     headers = Proc(HTTP::Server::Context, String, File::Info, Nil).new do |env, path, stat|
       if path =~ /\.html$/
@@ -181,6 +216,7 @@ describe Kemal::StaticFileHandler do
   end
 
   it "should handle requests with trailing slashes in nested paths" do
+    serve_static({"gzip" => true, "dir_listing" => true})
     response = handle HTTP::Request.new("GET", "/dir/nested/path/")
     response.status_code.should eq(200)
   end

--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -11,6 +11,12 @@ private def handle(request, fallthrough = true, decompress = true, public_dir = 
   HTTP::Client::Response.from_io(io, decompress: decompress)
 end
 
+class Kemal::StaticFileHandler
+  def read_file_bytes_for_spec(file_path : String, size : Int64)
+    read_file_bytes(file_path, size)
+  end
+end
+
 describe Kemal::StaticFileHandler do
   file = File.open "#{__DIR__}/static/dir/test.txt"
   File.open "#{__DIR__}/static/dir/nested/path/test.txt"
@@ -307,8 +313,8 @@ describe Kemal::StaticFileHandler do
     end
   end
 
-  it "should leave newer files uncached when the cache budget is full" do
-    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 12, "cache_check_interval" => 5_000})
+  it "should evict the least recently used file when the cache budget is full" do
+    serve_static({"gzip" => false, "dir_listing" => false, "cache" => true, "cache_size" => 16, "cache_check_interval" => 5_000})
     temp_dir = File.tempname("kemal-static-cache-budget")
     Dir.mkdir(temp_dir)
 
@@ -316,26 +322,44 @@ describe Kemal::StaticFileHandler do
       handler = Kemal::StaticFileHandler.new temp_dir
       first_path = File.join(temp_dir, "first.txt")
       second_path = File.join(temp_dir, "second.txt")
-      File.write(first_path, "first-one")
-      File.write(second_path, "second-a")
-
-      response = handle HTTP::Request.new("GET", "/first.txt"), public_dir: temp_dir, handler: handler
-      response.body.should eq("first-one")
-      response = handle HTTP::Request.new("GET", "/second.txt"), public_dir: temp_dir, handler: handler
-      response.body.should eq("second-a")
-
-      File.write(first_path, "first-two")
+      third_path = File.join(temp_dir, "third.txt")
+      File.write(first_path, "first-a")
       File.write(second_path, "second-b")
+      File.write(third_path, "third-c")
 
       response = handle HTTP::Request.new("GET", "/first.txt"), public_dir: temp_dir, handler: handler
-      response.body.should eq("first-one")
+      response.body.should eq("first-a")
+      sleep 2.milliseconds
       response = handle HTTP::Request.new("GET", "/second.txt"), public_dir: temp_dir, handler: handler
       response.body.should eq("second-b")
+      sleep 2.milliseconds
+      response = handle HTTP::Request.new("GET", "/first.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("first-a")
+      sleep 2.milliseconds
+      response = handle HTTP::Request.new("GET", "/third.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("third-c")
+
+      File.write(first_path, "first-z")
+      File.write(second_path, "second-z")
+      File.write(third_path, "third-z")
+
+      response = handle HTTP::Request.new("GET", "/first.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("first-a")
+      response = handle HTTP::Request.new("GET", "/third.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("third-c")
+      response = handle HTTP::Request.new("GET", "/second.txt"), public_dir: temp_dir, handler: handler
+      response.body.should eq("second-z")
     ensure
       File.delete?(File.join(temp_dir, "first.txt"))
       File.delete?(File.join(temp_dir, "second.txt"))
+      File.delete?(File.join(temp_dir, "third.txt"))
       Dir.delete(temp_dir)
     end
+  end
+
+  it "should not allocate cached bytes larger than Int32::MAX" do
+    handler = Kemal::StaticFileHandler.new "#{__DIR__}/static"
+    handler.read_file_bytes_for_spec("ignored", Int32::MAX.to_i64 + 1).should be_nil
   end
 
   it "should handle setting custom headers" do

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -161,18 +161,20 @@ module Kemal
       end
     end
 
-    def serve_static_size_option(name : String, default : Int64 = 0_i64) : Int64
+    def serve_static_size_option?(name : String) : Int64?
       config = @serve_static
-      return default unless config.is_a?(Hash)
+      return unless config.is_a?(Hash)
 
       case value = config[name]?
       when Int32
         value.to_i64
       when Int64
         value
-      else
-        default
       end
+    end
+
+    def serve_static_size_option(name : String, default : Int64 = 0_i64) : Int64
+      serve_static_size_option?(name) || default
     end
 
     def setup

--- a/src/kemal/config.cr
+++ b/src/kemal/config.cr
@@ -1,5 +1,6 @@
 module Kemal
   VERSION = {{ `shards version "#{__DIR__}"`.chomp.stringify }}
+  alias StaticFileConfigValue = Bool | Int32 | Int64
 
   # Stores all the configuration options for a Kemal application.
   # It's a singleton and you can access it like.
@@ -20,10 +21,11 @@ module Kemal
     {% else %}
       @ssl : OpenSSL::SSL::Context::Server?
     {% end %}
+    @serve_static : Bool | Hash(String, StaticFileConfigValue)
 
     property app_name, host_binding, ssl, port, env, public_folder, logging, running
     property always_rescue, server : HTTP::Server?, extra_options, shutdown_message, shutdown_timeout
-    property serve_static : (Bool | Hash(String, Bool))
+    getter serve_static : (Bool | Hash(String, StaticFileConfigValue))
     property static_headers : (HTTP::Server::Context, String, File::Info ->)?
     property? powered_by_header : Bool = true
     property max_route_cache_size : Int32
@@ -40,7 +42,7 @@ module Kemal
       @host_binding = "0.0.0.0"
       @port = 3000
       @env = ENV["KEMAL_ENV"]? || "development"
-      @serve_static = {"dir_listing" => false, "gzip" => true, "dir_index" => false}
+      @serve_static = {"dir_listing" => false, "gzip" => true, "dir_index" => false} of String => StaticFileConfigValue
       @public_folder = "./public"
       @logging = true
       @logger = nil
@@ -135,6 +137,42 @@ module Kemal
     end
 
     def extra_options(&@extra_options : OptionParser ->)
+    end
+
+    def serve_static=(value : Bool)
+      @serve_static = value
+    end
+
+    def serve_static=(value : Hash(String, V)) forall V
+      @serve_static = value.each_with_object({} of String => StaticFileConfigValue) do |(key, option), memo|
+        memo[key] = option.as(StaticFileConfigValue)
+      end
+    end
+
+    def serve_static_option?(name : String, default : Bool = false) : Bool
+      config = @serve_static
+      return default unless config.is_a?(Hash)
+
+      case value = config[name]?
+      when Bool
+        value
+      else
+        default
+      end
+    end
+
+    def serve_static_size_option(name : String, default : Int64 = 0_i64) : Int64
+      config = @serve_static
+      return default unless config.is_a?(Hash)
+
+      case value = config[name]?
+      when Int32
+        value.to_i64
+      when Int64
+        value
+      else
+        default
+      end
     end
 
     def setup

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -92,7 +92,9 @@ end
 #
 # Static server also have some advanced customization options like `dir_listing`,
 # `dir_index`, `gzip` and in-memory caching via `cache`, `cache_size` and
-# `cache_check_interval` (milliseconds).
+# `cache_check_interval` (milliseconds). Setting `cache_size` to `0` disables
+# byte caching. Setting `cache_check_interval` to `0` forces metadata
+# revalidation on every request.
 #
 # ```
 # serve_static({"gzip" => true, "dir_listing" => false, "cache" => true, "cache_size" => 4 * 1024 * 1024, "cache_check_interval" => 1_000})

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -91,10 +91,11 @@ end
 # ```
 #
 # Static server also have some advanced customization options like `dir_listing`,
-# `dir_index`, `gzip` and in-memory caching via `cache` / `cache_size`.
+# `dir_index`, `gzip` and in-memory caching via `cache`, `cache_size` and
+# `cache_check_interval` (milliseconds).
 #
 # ```
-# serve_static({"gzip" => true, "dir_listing" => false, "cache" => true, "cache_size" => 4 * 1024 * 1024})
+# serve_static({"gzip" => true, "dir_listing" => false, "cache" => true, "cache_size" => 4 * 1024 * 1024, "cache_check_interval" => 1_000})
 # ```
 def serve_static(status : Bool)
   Kemal.config.serve_static = status

--- a/src/kemal/helpers/helpers.cr
+++ b/src/kemal/helpers/helpers.cr
@@ -91,10 +91,10 @@ end
 # ```
 #
 # Static server also have some advanced customization options like `dir_listing`,
-# `dir_index` and `gzip`.
+# `dir_index`, `gzip` and in-memory caching via `cache` / `cache_size`.
 #
 # ```
-# serve_static({"gzip" => true, "dir_listing" => false})
+# serve_static({"gzip" => true, "dir_listing" => false, "cache" => true, "cache_size" => 4 * 1024 * 1024})
 # ```
 def serve_static(status : Bool)
   Kemal.config.serve_static = status
@@ -158,7 +158,7 @@ def send_file(env : HTTP::Server::Context, path : String, mime_type : String? = 
       env.response.content_length = filesize
       IO.copy(file, env.response)
     {% else %}
-      condition = config.is_a?(Hash) && config["gzip"]? == true && filesize > minsize && Kemal::Utils.zip_types(file_path)
+      condition = Kemal.config.serve_static_option?("gzip") && filesize > minsize && Kemal::Utils.zip_types(file_path)
       if condition && request_headers.includes_word?("Accept-Encoding", "gzip")
         env.response.headers["Content-Encoding"] = "gzip"
         Compress::Gzip::Writer.open(env.response) do |deflate|
@@ -175,6 +175,47 @@ def send_file(env : HTTP::Server::Context, path : String, mime_type : String? = 
       end
     {% end %}
   end
+  return
+end
+
+def send_file(env : HTTP::Server::Context, path : String, data : Slice(UInt8), filestat : File::Info, mime_type : String? = nil, *, filename : String? = nil, disposition : String? = nil)
+  file_path = File.expand_path(path, Dir.current)
+  mime_type ||= MIME.from_filename(file_path, "application/octet-stream")
+  env.response.content_type = mime_type
+  env.response.headers["Accept-Ranges"] = "bytes"
+  env.response.headers["X-Content-Type-Options"] = "nosniff"
+  minsize = 860 # http://webmasters.stackexchange.com/questions/31750/what-is-recommended-minimum-object-size-for-gzip-performance-benefits ??
+  request_headers = env.request.headers
+  filesize = data.bytesize
+  attachment(env, filename, disposition)
+
+  Kemal.config.static_headers.try(&.call(env, file_path, filestat))
+
+  file = IO::Memory.new(data)
+  if env.request.method == "GET" && env.request.headers.has_key?("Range")
+    return multipart(file, env)
+  end
+
+  {% if flag?(:without_zlib) %}
+    env.response.content_length = filesize
+    IO.copy(file, env.response)
+  {% else %}
+    condition = Kemal.config.serve_static_option?("gzip") && filesize > minsize && Kemal::Utils.zip_types(file_path)
+    if condition && request_headers.includes_word?("Accept-Encoding", "gzip")
+      env.response.headers["Content-Encoding"] = "gzip"
+      Compress::Gzip::Writer.open(env.response) do |deflate|
+        IO.copy(file, deflate)
+      end
+    elsif condition && request_headers.includes_word?("Accept-Encoding", "deflate")
+      env.response.headers["Content-Encoding"] = "deflate"
+      Compress::Deflate::Writer.open(env.response) do |deflate|
+        IO.copy(file, deflate)
+      end
+    else
+      env.response.content_length = filesize
+      IO.copy(file, env.response)
+    end
+  {% end %}
   return
 end
 

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -2,7 +2,7 @@ module Kemal
   class StaticFileHandler < HTTP::StaticFileHandler
     private DEFAULT_MEMORY_CACHE_SIZE    = 8_i64 * 1024 * 1024
     private DEFAULT_CACHE_CHECK_INTERVAL = 1_000_i64
-    private record CachedFile, data : Bytes, file_info : File::Info, checked_at : Time::Instant
+    private record CachedFile, data : Bytes, file_info : File::Info, checked_at : Time::Instant, accessed_at : Time::Instant
 
     @cached_files = {} of String => CachedFile
     @cached_bytes = 0_i64
@@ -159,12 +159,19 @@ module Kemal
     private def cached_file(file_path : String, force_revalidate : Bool = false) : CachedFile?
       return unless cache_enabled?
 
-      entry = @cache_lock.synchronize do
-        @cached_files[file_path]?
+      cached = nil
+      needs_revalidation = false
+      @cache_lock.synchronize do
+        if entry = @cached_files[file_path]?
+          if force_revalidate || cache_check_due?(entry)
+            needs_revalidation = true
+          else
+            cached = touch_cached_file(file_path, entry)
+          end
+        end
       end
-      return unless entry
-      return revalidate_cached_file(file_path) if force_revalidate
-      return entry unless cache_check_due?(entry)
+      return cached if cached
+      return unless needs_revalidation
 
       revalidate_cached_file(file_path)
     end
@@ -201,8 +208,9 @@ module Kemal
         end
 
         unless stored
+          evict_cached_files(data_size, cache_limit)
           if cache_capacity_available?(data_size, cache_limit)
-            cached_file = CachedFile.new(data, file_info, Time.instant)
+            cached_file = new_cached_file(data, file_info)
             stored = cached_file
             @cached_files[file_path] = cached_file
             @cached_bytes += data_size
@@ -271,10 +279,40 @@ module Kemal
       cached_info.size == file_info.size && cached_info.modification_time == file_info.modification_time
     end
 
+    private def new_cached_file(data : Bytes, file_info : File::Info) : CachedFile
+      now = Time.instant
+      CachedFile.new(data, file_info, now, now)
+    end
+
+    private def touch_cached_file(file_path : String, entry : CachedFile) : CachedFile
+      touched = CachedFile.new(entry.data, entry.file_info, entry.checked_at, Time.instant)
+      @cached_files[file_path] = touched
+      touched
+    end
+
     private def refresh_cached_file(file_path : String, entry : CachedFile) : CachedFile
-      refreshed = CachedFile.new(entry.data, entry.file_info, Time.instant)
+      now = Time.instant
+      refreshed = CachedFile.new(entry.data, entry.file_info, now, now)
       @cached_files[file_path] = refreshed
       refreshed
+    end
+
+    private def evict_cached_files(required_bytes : Int64, cache_limit : Int64)
+      while !cache_capacity_available?(required_bytes, cache_limit)
+        candidate = least_recently_used_cached_file
+        break unless candidate
+
+        file_path, entry = candidate
+        remove_cached_file(file_path, entry)
+      end
+    end
+
+    private def least_recently_used_cached_file : {String, CachedFile}?
+      return if @cached_files.empty?
+
+      @cached_files.min_by do |file_path, entry|
+        {entry.accessed_at, file_path}
+      end
     end
 
     private def cache_capacity_available?(data_size : Int64, cache_limit : Int64) : Bool
@@ -287,6 +325,8 @@ module Kemal
     end
 
     private def read_file_bytes(file_path : String, size : Int64) : Bytes?
+      return if size > Int32::MAX.to_i64
+
       data = Bytes.new(size.to_i)
       File.open(file_path) do |file|
         file.read_fully(data)

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -59,20 +59,26 @@ module Kemal
     end
 
     private def try_serve_cached_asset(context : HTTP::Server::Context, target : RequestTarget) : Bool
+      force_revalidate = conditional_cache_request?(context)
+
       if !target.is_dir_path
-        if cached = cached_file(target.file_path.to_s)
+        if cached = cached_file(target.file_path.to_s, force_revalidate)
           serve_cached_asset(context, target.file_path.to_s, cached)
           return true
         end
       elsif cacheable_directory_index?
         index_path = (target.file_path / "index.html").to_s
-        if cached = cached_file(index_path)
+        if cached = cached_file(index_path, force_revalidate)
           serve_cached_asset(context, index_path, cached)
           return true
         end
       end
 
       false
+    end
+
+    private def conditional_cache_request?(context : HTTP::Server::Context) : Bool
+      !!context.request.if_none_match || !!context.request.headers["If-Modified-Since"]?
     end
 
     private def serve_from_disk_or_fallthrough(context : HTTP::Server::Context, target : RequestTarget)
@@ -122,7 +128,7 @@ module Kemal
 
     private def serve_cached_asset(context : HTTP::Server::Context, file_path : String, cached : CachedFile, mime_path : String = file_path)
       last_modified = cached.file_info.modification_time
-      add_cache_headers(context.response.headers, last_modified)
+      add_static_cache_headers(context.response.headers, cached.file_info)
 
       if cache_request?(context, last_modified)
         context.response.status = :not_modified
@@ -135,7 +141,7 @@ module Kemal
 
     private def serve_static_asset(context : HTTP::Server::Context, file_path : String, file_info : File::Info, mime_path : String = file_path)
       last_modified = file_info.modification_time
-      add_cache_headers(context.response.headers, last_modified)
+      add_static_cache_headers(context.response.headers, file_info)
 
       if cache_request?(context, last_modified)
         context.response.status = :not_modified
@@ -150,13 +156,14 @@ module Kemal
       end
     end
 
-    private def cached_file(file_path : String) : CachedFile?
+    private def cached_file(file_path : String, force_revalidate : Bool = false) : CachedFile?
       return unless cache_enabled?
 
       entry = @cache_lock.synchronize do
         @cached_files[file_path]?
       end
       return unless entry
+      return revalidate_cached_file(file_path) if force_revalidate
       return entry unless cache_check_due?(entry)
 
       revalidate_cached_file(file_path)
@@ -194,7 +201,7 @@ module Kemal
         end
 
         unless stored
-          if @cached_bytes + data_size <= cache_limit
+          if cache_capacity_available?(data_size, cache_limit)
             cached_file = CachedFile.new(data, file_info, Time.instant)
             stored = cached_file
             @cached_files[file_path] = cached_file
@@ -224,15 +231,17 @@ module Kemal
     end
 
     private def memory_cache_limit : Int64
-      cache_size = Kemal.config.serve_static_size_option("cache_size")
-      return cache_size if cache_size.positive?
+      if cache_size = Kemal.config.serve_static_size_option?("cache_size")
+        return cache_size.positive? ? cache_size : 0_i64
+      end
+
       return DEFAULT_MEMORY_CACHE_SIZE if Kemal.config.serve_static_option?("cache")
 
       0_i64
     end
 
     private def cache_check_interval : Time::Span
-      interval = Kemal.config.serve_static_size_option("cache_check_interval", DEFAULT_CACHE_CHECK_INTERVAL)
+      interval = Kemal.config.serve_static_size_option?("cache_check_interval") || DEFAULT_CACHE_CHECK_INTERVAL
       interval = 0_i64 if interval.negative?
       interval.milliseconds
     end
@@ -248,6 +257,15 @@ module Kemal
       Time.instant - entry.checked_at >= interval
     end
 
+    private def add_static_cache_headers(headers : HTTP::Headers, file_info : File::Info)
+      headers["Etag"] = static_file_etag(file_info)
+      headers["Last-Modified"] = HTTP.format_time(file_info.modification_time)
+    end
+
+    private def static_file_etag(file_info : File::Info) : String
+      %(W/"#{file_info.modification_time.to_unix_ns}-#{file_info.size}")
+    end
+
     private def fresh_cache_entry?(entry : CachedFile, file_info : File::Info) : Bool
       cached_info = entry.file_info
       cached_info.size == file_info.size && cached_info.modification_time == file_info.modification_time
@@ -257,6 +275,10 @@ module Kemal
       refreshed = CachedFile.new(entry.data, entry.file_info, Time.instant)
       @cached_files[file_path] = refreshed
       refreshed
+    end
+
+    private def cache_capacity_available?(data_size : Int64, cache_limit : Int64) : Bool
+      @cached_bytes + data_size <= cache_limit
     end
 
     private def remove_cached_file(file_path : String, entry : CachedFile)

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -1,24 +1,111 @@
 module Kemal
   class StaticFileHandler < HTTP::StaticFileHandler
+    private DEFAULT_MEMORY_CACHE_SIZE = 8_i64 * 1024 * 1024
+    private record CachedFile, data : Bytes, file_info : File::Info
+
+    @cached_files = {} of String => CachedFile
+    @cached_bytes = 0_i64
+    @cache_lock = Mutex.new
+
+    private def serve_static_asset(context : HTTP::Server::Context, file_path : String, file_info : File::Info, mime_path : String = file_path)
+      last_modified = file_info.modification_time
+      add_cache_headers(context.response.headers, last_modified)
+
+      if cache_request?(context, last_modified)
+        context.response.status = :not_modified
+        return
+      end
+
+      mime_type = MIME.from_filename(mime_path, "application/octet-stream")
+      if cached = cached_file(file_path, file_info)
+        send_file(context, file_path, cached.data, cached.file_info, mime_type)
+      else
+        send_file(context, file_path, mime_type)
+      end
+    end
+
+    private def cached_file(file_path : String, file_info : File::Info) : CachedFile?
+      cache_limit = memory_cache_limit
+      return if cache_limit <= 0
+      return if file_info.size > cache_limit
+
+      cached = nil
+      @cache_lock.synchronize do
+        if entry = @cached_files[file_path]?
+          if fresh_cache_entry?(entry, file_info)
+            cached = entry
+          else
+            remove_cached_file(file_path, entry)
+          end
+        end
+      end
+      return cached if cached
+
+      data = read_file_bytes(file_path, file_info.size)
+      return unless data
+
+      stored = nil
+      data_size = data.bytesize.to_i64
+      @cache_lock.synchronize do
+        if entry = @cached_files[file_path]?
+          if fresh_cache_entry?(entry, file_info)
+            stored = entry
+          else
+            remove_cached_file(file_path, entry)
+          end
+        end
+
+        unless stored
+          if @cached_bytes + data_size <= cache_limit
+            stored = CachedFile.new(data, file_info)
+            @cached_files[file_path] = stored.not_nil!
+            @cached_bytes += data_size
+          end
+        end
+      end
+
+      stored
+    end
+
+    private def memory_cache_limit : Int64
+      cache_size = Kemal.config.serve_static_size_option("cache_size")
+      return cache_size if cache_size.positive?
+      return DEFAULT_MEMORY_CACHE_SIZE if Kemal.config.serve_static_option?("cache")
+
+      0_i64
+    end
+
+    private def fresh_cache_entry?(entry : CachedFile, file_info : File::Info) : Bool
+      cached_info = entry.file_info
+      cached_info.size == file_info.size && cached_info.modification_time == file_info.modification_time
+    end
+
+    private def remove_cached_file(file_path : String, entry : CachedFile)
+      @cached_files.delete(file_path)
+      @cached_bytes -= entry.data.bytesize.to_i64
+    end
+
+    private def read_file_bytes(file_path : String, size : Int64) : Bytes?
+      data = Bytes.new(size.to_i)
+      File.open(file_path) do |file|
+        file.read_fully(data)
+      end
+      data
+    rescue File::Error
+      nil
+    end
+
     {% if compare_versions(Crystal::VERSION, "1.17.0") >= 0 %}
       private def directory_index(context : HTTP::Server::Context, request_path : Path, file_path : Path)
-        config = Kemal.config.serve_static
-        unless config.is_a?(Hash)
+        config = Kemal.config
+        unless config.serve_static.is_a?(Hash)
           return call_next(context)
         end
 
         index_path = file_path / "index.html"
-        if config.fetch("dir_index", false) && (index_info = File.info?(index_path))
-          last_modified = index_info.modification_time
-          add_cache_headers(context.response.headers, last_modified)
-
-          if cache_request?(context, last_modified)
-            context.response.status = :not_modified
-            return
-          end
-
-          send_file(context, index_path.to_s)
-        elsif config.fetch("dir_listing", false)
+        if config.serve_static_option?("dir_index") && (index_info = File.info?(index_path))
+          serve_static_asset(context, index_path.to_s, index_info)
+        elsif config.serve_static_option?("dir_listing")
           context.response.content_type = "text/html; charset=utf-8"
           directory_listing(context.response, request_path, file_path)
         else
@@ -26,10 +113,8 @@ module Kemal
         end
       end
 
-      # NOTE: This override opts out of some behaviour from HTTP::StaticFileHandler,
-      # such as serving content ranges.
       private def serve_file(context : HTTP::Server::Context, file_info, file_path : Path, original_file_path : Path, last_modified : Time)
-        send_file(context, file_path.to_s)
+        serve_static_asset(context, file_path.to_s, file_info, original_file_path.to_s)
       end
     {% else %}
       def call(context : HTTP::Server::Context)
@@ -79,41 +164,22 @@ module Kemal
         return call_next(context) unless file_info
 
         if is_dir
-          config = Kemal.config.serve_static
+          config = Kemal.config
 
-          if config.is_a?(Hash) && config.fetch("dir_index", false) && File.exists?(File.join(file_path, "index.html"))
+          if config.serve_static.is_a?(Hash) && config.serve_static_option?("dir_index") && File.exists?(File.join(file_path, "index.html"))
             file_path = File.join(@public_dir, expanded_path, "index.html")
-
-            last_modified = modification_time(file_path)
-            add_cache_headers(context.response.headers, last_modified)
-
-            if cache_request?(context, last_modified)
-              context.response.status_code = 304
-              return
-            end
-            send_file(context, file_path)
-          elsif config.is_a?(Hash) && config.fetch("dir_listing", false)
+            serve_static_asset(context, file_path, File.info(file_path))
+          elsif config.serve_static.is_a?(Hash) && config.serve_static_option?("dir_listing")
             context.response.content_type = "text/html; charset=utf-8"
             directory_listing(context.response, request_path, file_path)
           else
             call_next(context)
           end
         elsif is_file
-          last_modified = modification_time(file_path)
-          add_cache_headers(context.response.headers, last_modified)
-
-          if cache_request?(context, last_modified)
-            context.response.status_code = 304
-            return
-          end
-          send_file(context, file_path.to_s)
+          serve_static_asset(context, file_path.to_s, file_info)
         else # Not a normal file (FIFO/device/socket)
           call_next(context)
         end
-      end
-
-      private def modification_time(file_path)
-        File.info(file_path).modification_time
       end
     {% end %}
   end

--- a/src/kemal/static_file_handler.cr
+++ b/src/kemal/static_file_handler.cr
@@ -1,11 +1,137 @@
 module Kemal
   class StaticFileHandler < HTTP::StaticFileHandler
-    private DEFAULT_MEMORY_CACHE_SIZE = 8_i64 * 1024 * 1024
-    private record CachedFile, data : Bytes, file_info : File::Info
+    private DEFAULT_MEMORY_CACHE_SIZE    = 8_i64 * 1024 * 1024
+    private DEFAULT_CACHE_CHECK_INTERVAL = 1_000_i64
+    private record CachedFile, data : Bytes, file_info : File::Info, checked_at : Time::Instant
 
     @cached_files = {} of String => CachedFile
     @cached_bytes = 0_i64
     @cache_lock = Mutex.new
+
+    private record RequestTarget, original_path : String, request_path : Path, expanded_path : Path, file_path : Path, is_dir_path : Bool
+
+    def call(context : HTTP::Server::Context)
+      original_path = context.request.path
+      return call_next(context) unless original_path
+      return call_next(context) if original_path == "/"
+
+      target = request_target(context, original_path)
+      return unless target
+      return unless allow_request_method?(context)
+      return if try_serve_cached_asset(context, target)
+
+      serve_from_disk_or_fallthrough(context, target)
+    end
+
+    private def request_target(context : HTTP::Server::Context, original_path : String) : RequestTarget?
+      is_dir_path = original_path.ends_with?("/")
+      decoded_path = URI.decode(original_path)
+
+      # File path cannot contains '\0' (NUL) because all filesystem I know
+      # don't accept '\0' character as file name.
+      if decoded_path.includes? '\0'
+        context.response.respond_with_status(:bad_request)
+        return
+      end
+
+      request_path = Path.posix(decoded_path)
+      expanded_path = request_path.expand("/")
+      if request_path != expanded_path
+        redirect_to context, expanded_path
+        return
+      end
+
+      file_path = @public_dir.join(expanded_path.to_kind(Path::Kind.native))
+      RequestTarget.new(original_path, request_path, expanded_path, file_path, is_dir_path)
+    end
+
+    private def allow_request_method?(context : HTTP::Server::Context) : Bool
+      return true if context.request.method.in?("GET", "HEAD")
+
+      if @fallthrough
+        call_next(context)
+      else
+        context.response.status_code = 405
+        context.response.headers.add("Allow", "GET, HEAD")
+      end
+
+      false
+    end
+
+    private def try_serve_cached_asset(context : HTTP::Server::Context, target : RequestTarget) : Bool
+      if !target.is_dir_path
+        if cached = cached_file(target.file_path.to_s)
+          serve_cached_asset(context, target.file_path.to_s, cached)
+          return true
+        end
+      elsif cacheable_directory_index?
+        index_path = (target.file_path / "index.html").to_s
+        if cached = cached_file(index_path)
+          serve_cached_asset(context, index_path, cached)
+          return true
+        end
+      end
+
+      false
+    end
+
+    private def serve_from_disk_or_fallthrough(context : HTTP::Server::Context, target : RequestTarget)
+      file_info = File.info?(target.file_path)
+      return call_next(context) unless file_info
+
+      if file_info.directory? && !target.is_dir_path
+        redirect_to context, target.expanded_path.join("")
+        return
+      end
+
+      if file_info.directory?
+        serve_directory(context, target)
+      elsif file_info.file?
+        serve_static_asset(context, target.file_path.to_s, file_info)
+      else
+        call_next(context)
+      end
+    end
+
+    private def serve_directory(context : HTTP::Server::Context, target : RequestTarget)
+      if cacheable_directory_index?
+        index_path = target.file_path / "index.html"
+        if index_info = File.info?(index_path)
+          serve_static_asset(context, index_path.to_s, index_info)
+          return
+        end
+      end
+
+      if directory_listing_enabled?
+        context.response.content_type = "text/html; charset=utf-8"
+        directory_listing(context.response, target.request_path, target.file_path)
+      else
+        call_next(context)
+      end
+    end
+
+    private def cacheable_directory_index? : Bool
+      config = Kemal.config
+      config.serve_static.is_a?(Hash) && config.serve_static_option?("dir_index")
+    end
+
+    private def directory_listing_enabled? : Bool
+      config = Kemal.config
+      config.serve_static.is_a?(Hash) && config.serve_static_option?("dir_listing")
+    end
+
+    private def serve_cached_asset(context : HTTP::Server::Context, file_path : String, cached : CachedFile, mime_path : String = file_path)
+      last_modified = cached.file_info.modification_time
+      add_cache_headers(context.response.headers, last_modified)
+
+      if cache_request?(context, last_modified)
+        context.response.status = :not_modified
+        return
+      end
+
+      mime_type = MIME.from_filename(mime_path, "application/octet-stream")
+      send_file(context, file_path, cached.data, cached.file_info, mime_type)
+    end
 
     private def serve_static_asset(context : HTTP::Server::Context, file_path : String, file_info : File::Info, mime_path : String = file_path)
       last_modified = file_info.modification_time
@@ -24,6 +150,18 @@ module Kemal
       end
     end
 
+    private def cached_file(file_path : String) : CachedFile?
+      return unless cache_enabled?
+
+      entry = @cache_lock.synchronize do
+        @cached_files[file_path]?
+      end
+      return unless entry
+      return entry unless cache_check_due?(entry)
+
+      revalidate_cached_file(file_path)
+    end
+
     private def cached_file(file_path : String, file_info : File::Info) : CachedFile?
       cache_limit = memory_cache_limit
       return if cache_limit <= 0
@@ -33,7 +171,7 @@ module Kemal
       @cache_lock.synchronize do
         if entry = @cached_files[file_path]?
           if fresh_cache_entry?(entry, file_info)
-            cached = entry
+            cached = refresh_cached_file(file_path, entry)
           else
             remove_cached_file(file_path, entry)
           end
@@ -49,7 +187,7 @@ module Kemal
       @cache_lock.synchronize do
         if entry = @cached_files[file_path]?
           if fresh_cache_entry?(entry, file_info)
-            stored = entry
+            stored = refresh_cached_file(file_path, entry)
           else
             remove_cached_file(file_path, entry)
           end
@@ -57,14 +195,32 @@ module Kemal
 
         unless stored
           if @cached_bytes + data_size <= cache_limit
-            stored = CachedFile.new(data, file_info)
-            @cached_files[file_path] = stored.not_nil!
+            cached_file = CachedFile.new(data, file_info, Time.instant)
+            stored = cached_file
+            @cached_files[file_path] = cached_file
             @cached_bytes += data_size
           end
         end
       end
 
       stored
+    end
+
+    private def revalidate_cached_file(file_path : String) : CachedFile?
+      file_info = File.info?(file_path)
+      refreshed = nil
+
+      @cache_lock.synchronize do
+        if entry = @cached_files[file_path]?
+          if file_info && fresh_cache_entry?(entry, file_info)
+            refreshed = refresh_cached_file(file_path, entry)
+          else
+            remove_cached_file(file_path, entry)
+          end
+        end
+      end
+
+      refreshed
     end
 
     private def memory_cache_limit : Int64
@@ -75,9 +231,32 @@ module Kemal
       0_i64
     end
 
+    private def cache_check_interval : Time::Span
+      interval = Kemal.config.serve_static_size_option("cache_check_interval", DEFAULT_CACHE_CHECK_INTERVAL)
+      interval = 0_i64 if interval.negative?
+      interval.milliseconds
+    end
+
+    private def cache_enabled? : Bool
+      memory_cache_limit.positive?
+    end
+
+    private def cache_check_due?(entry : CachedFile) : Bool
+      interval = cache_check_interval
+      return true if interval.zero?
+
+      Time.instant - entry.checked_at >= interval
+    end
+
     private def fresh_cache_entry?(entry : CachedFile, file_info : File::Info) : Bool
       cached_info = entry.file_info
       cached_info.size == file_info.size && cached_info.modification_time == file_info.modification_time
+    end
+
+    private def refresh_cached_file(file_path : String, entry : CachedFile) : CachedFile
+      refreshed = CachedFile.new(entry.data, entry.file_info, Time.instant)
+      @cached_files[file_path] = refreshed
+      refreshed
     end
 
     private def remove_cached_file(file_path : String, entry : CachedFile)
@@ -94,93 +273,5 @@ module Kemal
     rescue File::Error
       nil
     end
-
-    {% if compare_versions(Crystal::VERSION, "1.17.0") >= 0 %}
-      private def directory_index(context : HTTP::Server::Context, request_path : Path, file_path : Path)
-        config = Kemal.config
-        unless config.serve_static.is_a?(Hash)
-          return call_next(context)
-        end
-
-        index_path = file_path / "index.html"
-        if config.serve_static_option?("dir_index") && (index_info = File.info?(index_path))
-          serve_static_asset(context, index_path.to_s, index_info)
-        elsif config.serve_static_option?("dir_listing")
-          context.response.content_type = "text/html; charset=utf-8"
-          directory_listing(context.response, request_path, file_path)
-        else
-          call_next(context)
-        end
-      end
-
-      private def serve_file(context : HTTP::Server::Context, file_info, file_path : Path, original_file_path : Path, last_modified : Time)
-        serve_static_asset(context, file_path.to_s, file_info, original_file_path.to_s)
-      end
-    {% else %}
-      def call(context : HTTP::Server::Context)
-        return call_next(context) if context.request.path.not_nil! == "/"
-
-        case context.request.method
-        when "GET", "HEAD"
-        else
-          if @fallthrough
-            call_next(context)
-          else
-            context.response.status_code = 405
-            context.response.headers.add("Allow", "GET, HEAD")
-          end
-          return
-        end
-
-        original_path = context.request.path.not_nil!
-        is_dir_path = original_path.ends_with?("/")
-        request_path = URI.decode(original_path)
-
-        # File path cannot contains '\0' (NUL) because all filesystem I know
-        # don't accept '\0' character as file name.
-        if request_path.includes? '\0'
-          context.response.respond_with_status(:bad_request)
-          return
-        end
-
-        request_path = Path.posix(request_path)
-        expanded_path = request_path.expand("/")
-
-        file_path = @public_dir.join(expanded_path.to_kind(Path::Kind.native))
-        file_info = File.info? file_path
-        is_dir = @directory_listing && file_info && file_info.directory?
-        is_file = file_info && file_info.file?
-
-        if request_path != expanded_path || is_dir && !is_dir_path
-          redirect_path = expanded_path
-          if is_dir && !is_dir_path
-            # Append / to path if missing
-            redirect_path = expanded_path.join("")
-          end
-          redirect_to context, redirect_path
-          return
-        end
-
-        return call_next(context) unless file_info
-
-        if is_dir
-          config = Kemal.config
-
-          if config.serve_static.is_a?(Hash) && config.serve_static_option?("dir_index") && File.exists?(File.join(file_path, "index.html"))
-            file_path = File.join(@public_dir, expanded_path, "index.html")
-            serve_static_asset(context, file_path, File.info(file_path))
-          elsif config.serve_static.is_a?(Hash) && config.serve_static_option?("dir_listing")
-            context.response.content_type = "text/html; charset=utf-8"
-            directory_listing(context.response, request_path, file_path)
-          else
-            call_next(context)
-          end
-        elsif is_file
-          serve_static_asset(context, file_path.to_s, file_info)
-        else # Not a normal file (FIFO/device/socket)
-          call_next(context)
-        end
-      end
-    {% end %}
   end
 end


### PR DESCRIPTION
## Summary

This PR adds opt-in in-memory caching to `Kemal::StaticFileHandler` so frequently requested static assets can be served from memory instead of being reopened from disk on every request.

The cache is bounded by size, periodically revalidated against file metadata, and evicts least recently used entries when the cache budget is full. The implementation also preserves the existing static file behavior for `ETag` / `Last-Modified`, conditional requests, `HEAD`, `Range`, compression, and custom static headers.

```crystal
serve_static({
  "gzip" => true,
  "dir_listing" => false,
  "cache" => true,
  "cache_size" => 8 * 1024 * 1024,
  "cache_check_interval" => 1_000,
})
```

## Why

Serving hot static assets from memory reduces repeated disk I/O and file descriptor churn under load, which can improve throughput and make static file serving more predictable in production.

This also addresses the use case discussed in [#716](https://github.com/kemalcr/kemal/issues/716), while keeping cache correctness and memory usage under control.

## Design choices

- The cache is opt-in and configured through `serve_static`, so existing applications are unaffected unless they explicitly enable it.
- Cached entries are periodically revalidated using file metadata, while conditional requests force revalidation to avoid incorrect `304 Not Modified` responses.
- Cache size is bounded and eviction is deterministic, using a least-recently-used strategy when the cache budget is exceeded.
- Oversized files are served normally without entering the cache, and very large allocations are explicitly avoided.
- The cached response path preserves the same response semantics as the disk-backed path, including `HEAD`, `Range`, compression, and custom static headers.

## Backward compatibility

- Static file caching is disabled by default.
- Existing `serve_static` behavior remains unchanged unless the new cache-related options are provided.
- Existing features such as directory listing, directory index serving, gzip/deflate support, conditional requests, and range responses continue to behave as before.
- The change is additive, so applications that do not opt into caching should see no behavioral difference.

## Benchmark Results
Tested with a **7 MB** image file using `wrk` (100 connections, 30s). 

```crystal
serve_static({
  "gzip" => true,
  "dir_listing" => false,
  "cache" => true,
  "cache_size" => 8 * 1024 * 1024,
  "cache_check_interval" => 1_000,
})
```

| Metric | Without Cache | With Static Cache | Improvement |
| :--- | :--- | :--- | :--- |
| **Requests/sec** | 585.01 | **858.48** | **+46.7%** |
| **Transfer/sec** | 4.19 GB | **6.15 GB** | **+46.7%** |
| **Avg Latency** | 150.96 ms | **137.02 ms** | **~10% Faster** |

### 📈 Performance Gains

```mermaid
graph TD
    subgraph "Throughput (Req/Sec)"
    A[No Cache: 585]
    B[Static Cache: 858]
    style B fill:#2ecc71,stroke:#27ae60,stroke-width:2px
    end

    subgraph "Transfer Speed (GB/s)"
    C[No Cache: 4.19]
    D[Static Cache: 6.15]
    style D fill:#3498db,stroke:#2980b9,stroke-width:2px
    end
```