### PR TITLE
Fix Int32 overflow in SSE retry field

### DIFF
--- a/spec/event_stream_spec.cr
+++ b/spec/event_stream_spec.cr
@@ -25,6 +25,17 @@ describe Kemal::EventStream do
     client_response.body.should eq("event: tick\nid: 42\nretry: 3000\ndata: update\n\n")
   end
 
+  it "does not overflow on retry spans beyond Int32 milliseconds" do
+    # 60 days is 5_184_000_000 ms, well past Int32::MAX (~2.1e9).
+    sse "/events" do |stream, _|
+      stream.send("update", retry: 60.days)
+    end
+
+    request = HTTP::Request.new("GET", "/events")
+    client_response = call_request_on_app(request)
+    client_response.body.should eq("retry: 5184000000\ndata: update\n\n")
+  end
+
   it "splits multi-line data into separate data fields" do
     sse "/events" do |stream, _|
       stream.send("line one\nline two")

--- a/src/kemal/event_stream.cr
+++ b/src/kemal/event_stream.cr
@@ -30,7 +30,7 @@ module Kemal
         validate_single_line!("id", id_value)
         @response.puts "id: #{id_value}"
       end
-      @response.puts "retry: #{retry.total_milliseconds.to_i}" if retry
+      @response.puts "retry: #{retry.total_milliseconds.to_i64}" if retry
       each_sse_line(data) do |line|
         @response.puts "data: #{line}"
       end


### PR DESCRIPTION
## What

`EventStream#send` rendered the SSE `retry` field with `.to_i` (Int32). A retry span longer than ~24.8 days (`Int32::MAX` milliseconds) overflowed and raised `OverflowError` **inside the streaming handler**, breaking the response. Switched to `.to_i64`.

## Bug case (before this PR)

```crystal
sse "/events" do |stream, _|
  stream.send("update", retry: 60.days)  # 5_184_000_000 ms
  # => raises OverflowError: Arithmetic overflow
end
```

Values within the normal range (seconds/minutes) are unaffected — the emitted bytes are identical.

## Test

Added a regression spec asserting `retry: 60.days` renders `retry: 5184000000`.
