### PR TITLE
feat(skills): integrate modular domain skills and modernize crystal-kemal

### DIFF
--- a/.github/skills/crystal-kemal/SKILL.md
+++ b/.github/skills/crystal-kemal/SKILL.md
@@ -69,7 +69,7 @@ Dynamic route parameters:
 
 ```crystal
 get "/users/:id" do |env|
-  id = env.params.url["id"]
+  id = env.params.url["id"]?
   env.json({id: id})
 end
 ```
@@ -78,33 +78,33 @@ Wildcard remainder:
 
 ```crystal
 get "/files/*all" do |env|
-  env.params.url["all"]
+  env.params.url["all"]?
 end
 ```
 
-For `QUERY`, use the same Kemal parameter APIs appropriate to the request body. A QUERY request with a body and no `Content-Type` is rejected according to Kemal's current behavior.
+For `QUERY` (RFC 10008, Kemal master / upcoming 1.13.0), use the same Kemal parameter APIs appropriate to the request body. A QUERY request with a body and no `Content-Type` is rejected with 400 Bad Request according to Kemal's current behavior.
 
 ## Parameters
 
 Query parameters:
 
 ```crystal
-width = env.params.query["width"]
+width = env.params.query["width"]?
 ```
 
 JSON body (`Content-Type: application/json`):
 
 ```crystal
-name = env.params.json["name"].as(String)
+name = env.params.json["name"]?.as?(String)
 ```
 
 Form/body parameters:
 
 ```crystal
-name = env.params.body["name"].as(String)
+name = env.params.body["name"]?.as?(String)
 ```
 
-Repeated/bracketed form keys must be accessed exactly as sent, for example `env.params.body["likes[]"]`.
+Repeated/bracketed form keys must be accessed exactly as sent, for example `env.params.body["likes[]"]?`.
 
 Uploads are available through `env.params.files`.
 
@@ -114,7 +114,7 @@ Prefer response helpers when they express the result clearly:
 
 ```crystal
 get "/users" do |env|
-  env.json({users: ["alice", "bob"]})
+  env.json({users: %w[alice bob]})
 end
 
 post "/users" do |env|
@@ -128,7 +128,7 @@ Use `halt` inside routes when route execution must stop:
 
 ```crystal
 get "/admin" do |env|
-  halt env.status(403).html("<h1>Forbidden</h1>")
+  halt env.status(:forbidden).html("<h1>Forbidden</h1>")
 end
 ```
 
@@ -141,7 +141,7 @@ api = Kemal::Router.new
 
 api.namespace "/users" do
   get "/" do |env|
-    env.json({users: ["alice", "bob"]})
+    env.json({users: %w[alice bob]})
   end
 end
 
@@ -173,7 +173,11 @@ class CustomHandler < Kemal::Handler
   end
 end
 
-add_handler CustomHandler.new
+# Preferred modern registration (Kemal 1.10+):
+use CustomHandler.new
+
+# Or configure on Kemal.config:
+# Kemal.config.add_handler CustomHandler.new
 ```
 
 Do not call `call_next` after intentionally short-circuiting the request.
@@ -251,6 +255,24 @@ Before considering Kemal work complete:
 - [ ] Relevant `spec-kemal` tests pass.
 - [ ] Production build and deployment behavior are verified for the target platform.
 
+## Specialized domain skills
+
+For targeted domain implementations with tested patterns from `kemal-by-example`, see the dedicated domain skills:
+
+- **Core Routing & Handlers**: [`kemal-core`](../kemal-core/SKILL.md)
+- **Real-Time WebSockets**: [`kemal-websocket`](../kemal-websocket/SKILL.md)
+- **Server-Sent Events (SSE)**: [`kemal-sse`](../kemal-sse/SKILL.md)
+- **JSON APIs & Helpers**: [`kemal-json`](../kemal-json/SKILL.md)
+- **Middleware & HMAC**: [`kemal-middleware`](../kemal-middleware/SKILL.md)
+- **File Uploads & Security**: [`kemal-upload`](../kemal-upload/SKILL.md)
+- **Authentication & Sessions**: [`kemal-auth`](../kemal-auth/SKILL.md)
+- **SQLite Database & Models**: [`kemal-database`](../kemal-database/SKILL.md)
+- **OAuth2 Integration**: [`kemal-oauth`](../kemal-oauth/SKILL.md)
+- **Crecto ORM**: [`kemal-orm`](../kemal-orm/SKILL.md)
+- **Views & ECR Templates**: [`kemal-view`](../kemal-view/SKILL.md)
+
 ## Sources
 
-Treat the current Kemal repository and official Kemal documentation as the source of truth. Use current APIs when this skill conflicts with newer project documentation.
+Treat the current Kemal repository and official Kemal documentation as the source of truth.
+
+The modular skill definitions are maintained and formally verified under [kemal-skills](https://gitlab.com/renich/kemal-skills).

--- a/.github/skills/crystal-kemal/SKILL.md
+++ b/.github/skills/crystal-kemal/SKILL.md
@@ -82,7 +82,7 @@ get "/files/*all" do |env|
 end
 ```
 
-For `QUERY` (RFC 10008, Kemal master / upcoming 1.13.0), use the same Kemal parameter APIs appropriate to the request body. A QUERY request with a body and no `Content-Type` is rejected with 400 Bad Request according to Kemal's current behavior.
+For `QUERY` (RFC 10008, on Kemal master and not yet in a stable release), use the same Kemal parameter APIs appropriate to the request body. A QUERY request with a body and no `Content-Type` is rejected with 400 Bad Request according to Kemal's current behavior.
 
 ## Parameters
 
@@ -257,7 +257,7 @@ Before considering Kemal work complete:
 
 ## Specialized domain skills
 
-For targeted domain implementations with tested patterns from `kemal-by-example`, see the dedicated domain skills:
+For targeted domain implementations with tested patterns from [`kemal-by-example`](https://github.com/sdogruyol/kemal-by-example), see the dedicated domain skills:
 
 - **Core Routing & Handlers**: [`kemal-core`](../kemal-core/SKILL.md)
 - **Real-Time WebSockets**: [`kemal-websocket`](../kemal-websocket/SKILL.md)

--- a/.github/skills/crystal-kemal/references/realtime-state.md
+++ b/.github/skills/crystal-kemal/references/realtime-state.md
@@ -43,20 +43,19 @@ end
 Configure browser WebSocket origin policy with
 `Kemal.config.websocket_allowed_origins`.
 
-By default, an empty `websocket_allowed_origins` list enforces same-origin
-WebSocket connections.
+On Kemal master (unreleased), an empty `websocket_allowed_origins` list enforces same-origin
+WebSocket connections. On Kemal 1.12.0 release, an empty list permits all origins by default.
 
-Use an explicit allowlist when trusted cross-origin browser clients need
-access:
+Use an explicit allowlist when trusted cross-origin browser clients need access (mandatory on 1.12.0 for CSWSH protection):
 
 ```crystal
-Kemal.config.websocket_allowed_origins = [
-  "https://myapp.com",
-  "http://localhost:3000",
+Kemal.config.websocket_allowed_origins = %w[
+  https://myapp.com
+  http://localhost:3000
 ]
 ```
 
-To explicitly allow connections from any origin:
+To explicitly allow connections from any origin (on master):
 
 ```crystal
 Kemal.config.websocket_allowed_origins = ["*"]

--- a/.github/skills/crystal-kemal/references/realtime-state.md
+++ b/.github/skills/crystal-kemal/references/realtime-state.md
@@ -43,10 +43,10 @@ end
 Configure browser WebSocket origin policy with
 `Kemal.config.websocket_allowed_origins`.
 
-On Kemal master (unreleased), an empty `websocket_allowed_origins` list enforces same-origin
-WebSocket connections. On Kemal 1.12.0 release, an empty list permits all origins by default.
+On Kemal master (not yet in a stable release), an empty `websocket_allowed_origins` list enforces same-origin
+WebSocket connections. On stable releases (1.12.0 and earlier), an empty list permits all origins by default.
 
-Use an explicit allowlist when trusted cross-origin browser clients need access (mandatory on 1.12.0 for CSWSH protection):
+Use an explicit allowlist when trusted cross-origin browser clients need access (mandatory on 1.12.0 and earlier for CSWSH protection):
 
 ```crystal
 Kemal.config.websocket_allowed_origins = %w[

--- a/.github/skills/kemal-auth/SKILL.md
+++ b/.github/skills/kemal-auth/SKILL.md
@@ -1,0 +1,173 @@
+---
+name: kemal-auth
+description: User authentication and session management in Kemal, following established project patterns.
+---
+
+# Kemal Authentication & Sessions
+
+This skill provides expert guidance on implementing user authentication and session management in Kemal, strictly following patterns from `src/kemal-by-example/ecommerce/` and `src/kemal-by-example/oauth-login/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `kemal-session` Integration | Supported | Supported |
+| Password Hashing (`Crypto::Bcrypt::Password`) | Supported | Supported |
+| Session-backed Auth Middleware & Helpers | Supported | Supported |
+| CSRF Protection via POST Actions | Supported | Supported |
+
+## Core Mandates
+
+- **Dependencies:** Always `require "kemal-session"`.
+- **Session Configuration:** Use `Kemal::Session.config` to set `secret`, `cookie_name`, and `gc_interval`:
+
+  ```crystal
+  Kemal::Session.config do |config|
+    config.secret = ENV["KEMAL_SESSION_SECRET"]? || raise "KEMAL_SESSION_SECRET not set"
+    config.cookie_name = "your_app_session"
+    config.gc_interval = 2.minutes
+  end
+  ```
+
+- **Auth Helpers:** Implement auth logic in a module (e.g., `Ecommerce::Auth`):
+  - `current_user(env)`: Use `env.session.bigint?("user_id")` to retrieve the ID and find the user
+  - `require_user(env)`: Call `current_user(env)` and redirect to `/login` if `nil`
+  - `sign_in(env, user)`: Set `env.session.bigint("user_id", user.id || raise "User ID required")`
+  - `sign_out(env)`: Call `env.session.destroy`
+
+- **Password Hashing:** Use `Crypto::Bcrypt::Password` for securely storing and authenticating passwords.
+- **Error Handling:** Use specific exception types (like `DB::Error`) in auth helpers.
+
+  ```crystal
+  def current_user(env) : User?
+    user_id = env.session.bigint?("user_id")
+    return unless user_id
+    User.find(user_id)
+  rescue DB::Error
+    nil
+  end
+  ```
+
+## Patterns from Source Code
+
+### Auth Helper Module (ecommerce/src/helpers/auth.cr)
+
+```crystal
+module Ecommerce
+  module Auth
+    extend self
+
+    def current_user(env) : User?
+      user_id = env.session.bigint?("user_id")
+      return unless user_id
+      User.find(user_id)
+    rescue DB::Error
+      nil
+    end
+
+    def require_user(env) : User?
+      user = current_user(env)
+      return user if user
+      env.redirect "/login"
+      nil
+    end
+
+    def sign_in(env, user : User)
+      user_id = user.id || raise ArgumentError.new("Cannot sign in user without ID")
+      env.session.bigint("user_id", user_id)
+    end
+
+    def sign_out(env)
+      env.session.destroy
+    end
+  end
+end
+```
+
+### Session Secret (Explicit Configuration)
+
+From ecommerce and oauth-login:
+
+```crystal
+Kemal::Session.config do |config|
+  config.secret = ENV["KEMAL_SESSION_SECRET"]? || raise "KEMAL_SESSION_SECRET not set"
+  config.cookie_name = "ecommerce_session_id"
+  config.gc_interval = 2.minutes
+end
+```
+
+### User Model with Bcrypt
+
+From ecommerce/src/models/user.cr:
+
+```crystal
+require "crypto/bcrypt"
+
+class User
+  include DB::Serializable
+
+  getter id : Int64?
+  getter name : String
+  getter email : String
+  getter password_hash : String
+  getter created_at : String
+  getter updated_at : String
+
+  def self.create(name : String, email : String, password : String) : User
+    now = Time.utc.to_s
+    normalized_email = normalize_email(email)
+    password_hash = Crypto::Bcrypt::Password.create(password, cost: 12).to_s
+    # ... insert and return user
+  end
+
+  def self.authenticate(email : String, password : String) : User?
+    user = find_by_email(normalize_email(email))
+    return unless user
+    return user if Crypto::Bcrypt::Password.new(user.password_hash).verify(password)
+    nil
+  end
+
+  def self.normalize_email(value : String) : String
+    value.strip.downcase
+  end
+end
+```
+
+### Login Route Pattern
+
+```crystal
+post "/login" do |env|
+  email = env.params.body["email"]?.try(&.strip) || ""
+  password = env.params.body["password"]?.try(&.strip) || ""
+  user = User.authenticate(email, password)
+
+  if user
+    Ecommerce::Auth.sign_in(env, user)
+    env.redirect "/products"
+  else
+    current_user = nil
+    cart_count = 0_i64
+    error_message = "Invalid email or password."
+    env.response.status = :unprocessable_entity
+    render "src/views/auth/login.ecr", "src/views/layouts/application.ecr"
+  end
+end
+
+post "/logout" do |env|
+  Ecommerce::Auth.sign_out(env)
+  env.redirect "/products"
+end
+```
+
+## Best Practices
+
+- **Local Variables for Errors:** Pass error messages as local variables directly to the `render` macro (e.g., `error_message = "Invalid email or password."`).
+- **Security:** Use `POST` for login and logout routes to prevent CSRF.
+- **Session Safe Access:** Use `env.session.bigint?("user_id")` or similar to safely retrieve session data.
+- **Model Methods:** Implement `User.authenticate(email, password)` and `User.find_by_email(email)` in the model.
+
+## When to Use
+
+- When implementing signup, login, or logout features.
+- When protecting specific routes from unauthorized access.
+- When managing user-specific state across requests.

--- a/.github/skills/kemal-auth/SKILL.md
+++ b/.github/skills/kemal-auth/SKILL.md
@@ -1,20 +1,12 @@
 ---
 name: kemal-auth
 description: User authentication and session management in Kemal, following established project patterns.
+license: MIT
 ---
 
 # Kemal Authentication & Sessions
 
-This skill provides expert guidance on implementing user authentication and session management in Kemal, strictly following patterns from `src/kemal-by-example/ecommerce/` and `src/kemal-by-example/oauth-login/`.
-
-## Compatibility Matrix
-
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `kemal-session` Integration | Supported | Supported |
-| Password Hashing (`Crypto::Bcrypt::Password`) | Supported | Supported |
-| Session-backed Auth Middleware & Helpers | Supported | Supported |
-| CSRF Protection via POST Actions | Supported | Supported |
+This skill provides expert guidance on implementing user authentication and session management in Kemal, strictly following patterns from [`kemal-by-example/ecommerce`](https://github.com/sdogruyol/kemal-by-example/tree/master/ecommerce) and [`kemal-by-example/oauth-login`](https://github.com/sdogruyol/kemal-by-example/tree/master/oauth-login).
 
 ## Core Mandates
 
@@ -162,7 +154,7 @@ end
 ## Best Practices
 
 - **Local Variables for Errors:** Pass error messages as local variables directly to the `render` macro (e.g., `error_message = "Invalid email or password."`).
-- **Security:** Use `POST` for login and logout routes to prevent CSRF.
+- **Security:** Use `POST` (never `GET`) for login and logout so state changes are not triggerable via simple links — but note that using `POST` alone does **not** prevent CSRF. Add real CSRF protection: validate a per-session CSRF token on state-changing requests (e.g. the [`kemal-csrf`](https://github.com/kemalcr/kemal-csrf) handler) and set session cookies with `SameSite`. Regenerate the session on login to prevent session fixation.
 - **Session Safe Access:** Use `env.session.bigint?("user_id")` or similar to safely retrieve session data.
 - **Model Methods:** Implement `User.authenticate(email, password)` and `User.find_by_email(email)` in the model.
 

--- a/.github/skills/kemal-core/SKILL.md
+++ b/.github/skills/kemal-core/SKILL.md
@@ -1,30 +1,31 @@
 ---
 name: kemal-core
 description: Core Kemal development (routing verbs, parameters, modular router, version gates, response helpers).
+license: MIT
 ---
 
 # Kemal Core Development
 
-This skill provides expert guidance on using the Kemal web framework for Crystal, with clear version gating between Kemal 1.12.0 release and upcoming Kemal master features.
+This skill provides expert guidance on using the Kemal web framework for Crystal, with version notes for features that are not yet in a stable release.
 
-## Compatibility Matrix
+## Version Notes
 
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| Core Verbs (`get`, `post`, `put`, `patch`, `delete`, `options`) | Supported | Supported |
-| Modular Router (`Kemal::Router`, `mount`, `namespace`) | Supported | Supported |
-| Response Helpers (`env.json`, `env.status`, `env.html`, `env.text`) | Supported (1.10+) | Supported |
-| HTTP `QUERY` Method (RFC 10008) | **Not available** | Supported (`query`, `before_query`, `after_query`) |
-| Range Request Bounds (`Kemal.config.max_ranges`) | **Not available** | Supported (default 16) |
+Everything in this skill works on current Kemal unless marked otherwise.
+
+- HTTP `QUERY` method (RFC 10008) — `query`, `before_query`, `after_query`: Kemal master only, not yet in a stable release (on 1.12.0 and earlier, use `post` or `get` with query parameters).
+- `Kemal.config.max_ranges` (Range request bounds): Kemal master only.
+- Response helpers (`env.json`, `env.status`, `env.html`, `env.text`): since Kemal 1.10.
+- `Kemal::Router`, `mount`, `namespace`: since Kemal 1.10.
+- `Kemal.config.max_request_body_size`: since Kemal 1.9. `Kemal.config.shutdown_timeout`: since Kemal 1.10.1.
 
 ## Core Mandates
 
 - **Routing:** Use top-level route methods (`get`, `post`, `put`, `patch`, `delete`, `options`) or modular routers (`Kemal::Router`).
-- **HTTP QUERY Method (RFC 10008) — *[Kemal Master / Unreleased]*:**
+- **HTTP QUERY Method (RFC 10008) — *[Kemal master only]*:**
   - On Kemal master, use `query` for safe, read-only queries with complex request bodies (JSON or form-encoded):
 
   ```crystal
-  # Available on Kemal master / upcoming 1.13.0 release:
+  # Kemal master only (not yet in a stable release):
   query "/search" do |env|
     q = env.params.json["q"]?.as?(String)
     halt env.status(:bad_request).json({error: "Query parameter 'q' required"}) unless q
@@ -33,9 +34,9 @@ This skill provides expert guidance on using the Kemal web framework for Crystal
   end
   ```
 
-  *Note*: A `QUERY` request carrying a body without a `Content-Type` header is rejected with `400 Bad Request`. On Kemal 1.12.0, use `post` or query parameters via `get` instead.
+  *Note*: A `QUERY` request carrying a body without a `Content-Type` header is rejected with `400 Bad Request`. On 1.12.0 and earlier, use `post` or query parameters via `get` instead.
 
-- **Modular Routers (Kemal 1.12.0+):** Use `Kemal::Router.new` for namespaced routes, scoped middleware, and mounting under path prefixes:
+- **Modular Routers (Kemal 1.10+):** Use `Kemal::Router.new` for namespaced routes, scoped middleware, and mounting under path prefixes:
 
   ```crystal
   api = Kemal::Router.new
@@ -121,7 +122,7 @@ admin_router.namespace "/posts" do
     end
   end
 
-  # HTTP QUERY (Kemal master / upcoming 1.13.0):
+  # HTTP QUERY (Kemal master only):
   query "/search" do |env|
     term = env.params.json["term"]?.as?(String)
     halt env.status(:bad_request).json({error: "Search term required"}) unless term
@@ -141,12 +142,12 @@ mount "/admin", admin_router
   ```crystal
   Kemal.config.max_request_body_size = 50 * 1024 * 1024 # 50 MB
   ```
-- **Range Request Bounds (Kemal Master / Unreleased):** On Kemal master, Kemal bounds HTTP `Range` request parts (default 16) to mitigate CVE-2011-3192 resource exhaustion:
+- **Range Request Bounds (Kemal master only):** On Kemal master, Kemal bounds HTTP `Range` request parts (default 16) to mitigate CVE-2011-3192 resource exhaustion:
   ```crystal
-  # Kemal master / upcoming 1.13.0:
+  # Kemal master only:
   Kemal.config.max_ranges = 16 # set to 0 to ignore Range headers entirely
   ```
-- **Graceful Shutdown (Kemal 1.10+):** Configure shutdown timeout so in-flight requests finish cleanly before exit:
+- **Graceful Shutdown (Kemal 1.10.1+):** Configure shutdown timeout so in-flight requests finish cleanly before exit:
   ```crystal
   Kemal.config.shutdown_timeout = 10.seconds
   ```
@@ -154,8 +155,8 @@ mount "/admin", admin_router
 ## When to Use
 
 - When creating or modifying routes in a Kemal application.
-- When organizing modular route namespaces with `Kemal::Router` (Kemal 1.12.0+).
+- When organizing modular route namespaces with `Kemal::Router` (Kemal 1.10+).
 - When handling incoming request parameters (URL, body, query, JSON, files, raw body).
-- When implementing search/filter endpoints (using `get`/`post` on 1.12.0 or `query` on master).
+- When implementing search/filter endpoints (using `get`/`post` on 1.12.0 and earlier, or `query` on master).
 - When returning JSON, HTML, or plain text responses.
 - When configuring global runtime settings and security bounds for Kemal.

--- a/.github/skills/kemal-core/SKILL.md
+++ b/.github/skills/kemal-core/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: kemal-core
+description: Core Kemal development (routing verbs, parameters, modular router, version gates, response helpers).
+---
+
+# Kemal Core Development
+
+This skill provides expert guidance on using the Kemal web framework for Crystal, with clear version gating between Kemal 1.12.0 release and upcoming Kemal master features.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| Core Verbs (`get`, `post`, `put`, `patch`, `delete`, `options`) | Supported | Supported |
+| Modular Router (`Kemal::Router`, `mount`, `namespace`) | Supported | Supported |
+| Response Helpers (`env.json`, `env.status`, `env.html`, `env.text`) | Supported (1.10+) | Supported |
+| HTTP `QUERY` Method (RFC 10008) | **Not available** | Supported (`query`, `before_query`, `after_query`) |
+| Range Request Bounds (`Kemal.config.max_ranges`) | **Not available** | Supported (default 16) |
+
+## Core Mandates
+
+- **Routing:** Use top-level route methods (`get`, `post`, `put`, `patch`, `delete`, `options`) or modular routers (`Kemal::Router`).
+- **HTTP QUERY Method (RFC 10008) — *[Kemal Master / Unreleased]*:**
+  - On Kemal master, use `query` for safe, read-only queries with complex request bodies (JSON or form-encoded):
+
+  ```crystal
+  # Available on Kemal master / upcoming 1.13.0 release:
+  query "/search" do |env|
+    q = env.params.json["q"]?.as?(String)
+    halt env.status(:bad_request).json({error: "Query parameter 'q' required"}) unless q
+    results = Product.search(q)
+    env.json({results: results})
+  end
+  ```
+
+  *Note*: A `QUERY` request carrying a body without a `Content-Type` header is rejected with `400 Bad Request`. On Kemal 1.12.0, use `post` or query parameters via `get` instead.
+
+- **Modular Routers (Kemal 1.12.0+):** Use `Kemal::Router.new` for namespaced routes, scoped middleware, and mounting under path prefixes:
+
+  ```crystal
+  api = Kemal::Router.new
+  api.namespace "/users" do
+    get "/" do |env|
+      env.json({users: %w[alice bob]})
+    end
+    get "/:id" do |env|
+      env.text "user #{env.params.url["id"]?}"
+    end
+  end
+
+  mount "/api/v1", api
+  ```
+
+- **Parameters:** Match parameters to request encoding (they are not interchangeable):
+  - URL parameters: `env.params.url["id"]` (raises on missing key) or `env.params.url["id"]?` (safe access)
+  - Body parameters (`application/x-www-form-urlencoded` or multipart): `env.params.body["name"]?`
+  - Query parameters (`?key=val`): `env.params.query["search"]?`
+  - JSON parameters (`application/json`): `env.params.json["field"]?.as?(String)`
+  - File parameters: `env.params.files["file"]`
+  - Raw request body: `env.params.raw_body` (for multi-handler raw body access)
+
+- **Response Helpers:** Use context response helpers (`env.json`, `env.status`, `env.html`, `env.text`, `halt`). For deep JSON API patterns and status helpers, refer to [`kemal-json`](../kemal-json/SKILL.md).
+
+- **Rendering:** Use the `render` macro with view and optional layout paths (see [`kemal-view`](../kemal-view/SKILL.md)):
+
+  ```crystal
+  render "src/views/posts/index.ecr", "src/views/layouts/application.ecr"
+  ```
+
+- **Middleware Registration:** Use `use` (Kemal 1.10+) or `Kemal.config.add_handler` (see [`kemal-middleware`](../kemal-middleware/SKILL.md)):
+  - Path-specific middleware: `use "/api", [CORSHandler.new, AuthHandler.new]`
+  - Global middleware: `use MyHandler.new`
+
+## Patterns from Source Code
+
+### URL Parameter Access (Safe Pattern)
+
+Always use the safe pattern for URL parameters to handle missing or invalid IDs:
+
+```crystal
+# Use the `?` accessor and `to_i64?` for IDs:
+id = env.params.url["id"]?.try(&.to_i64?)
+halt env.status(:bad_request).json({error: "Invalid ID"}) unless id
+post = Post.find(id)
+```
+
+### Body Parameter Access & Raw Body
+
+Always use safe access with `try` for body parameters:
+
+```crystal
+title = env.params.body["title"]?.try(&.strip) || ""
+body = env.params.body["body"]?.try(&.strip) || ""
+
+# Access raw request body across multiple handlers:
+raw = env.params.raw_body
+```
+
+### Modular Router with Namespaces
+
+Organize sub-systems cleanly using `Kemal::Router`:
+
+```crystal
+require "kemal"
+
+admin_router = Kemal::Router.new
+
+admin_router.namespace "/posts" do
+  get "/" do |env|
+    posts = Post.all
+    env.json(posts.map(&.to_h))
+  end
+
+  get "/:id" do |env|
+    id = env.params.url["id"]?.try(&.to_i64?)
+    post = id ? Post.find(id) : nil
+    if post
+      env.json(post.to_h)
+    else
+      halt env.status(:not_found).json({error: "Post not found"})
+    end
+  end
+
+  # HTTP QUERY (Kemal master / upcoming 1.13.0):
+  query "/search" do |env|
+    term = env.params.json["term"]?.as?(String)
+    halt env.status(:bad_request).json({error: "Search term required"}) unless term
+    posts = Post.search(term)
+    env.json(posts.map(&.to_h))
+  end
+end
+
+mount "/admin", admin_router
+```
+
+## Best Practices
+
+- **Separation of Concerns:** Keep route logic minimal. Delegate complex operations to models or services.
+- **Static Files:** Kemal serves files from the `public` directory by default. Configure this via `Kemal.config.public_folder`.
+- **Request Body Size Limits (Kemal 1.9+):** Limit maximum request body size to prevent DoS:
+  ```crystal
+  Kemal.config.max_request_body_size = 50 * 1024 * 1024 # 50 MB
+  ```
+- **Range Request Bounds (Kemal Master / Unreleased):** On Kemal master, Kemal bounds HTTP `Range` request parts (default 16) to mitigate CVE-2011-3192 resource exhaustion:
+  ```crystal
+  # Kemal master / upcoming 1.13.0:
+  Kemal.config.max_ranges = 16 # set to 0 to ignore Range headers entirely
+  ```
+- **Graceful Shutdown (Kemal 1.10+):** Configure shutdown timeout so in-flight requests finish cleanly before exit:
+  ```crystal
+  Kemal.config.shutdown_timeout = 10.seconds
+  ```
+
+## When to Use
+
+- When creating or modifying routes in a Kemal application.
+- When organizing modular route namespaces with `Kemal::Router` (Kemal 1.12.0+).
+- When handling incoming request parameters (URL, body, query, JSON, files, raw body).
+- When implementing search/filter endpoints (using `get`/`post` on 1.12.0 or `query` on master).
+- When returning JSON, HTML, or plain text responses.
+- When configuring global runtime settings and security bounds for Kemal.

--- a/.github/skills/kemal-database/SKILL.md
+++ b/.github/skills/kemal-database/SKILL.md
@@ -1,0 +1,233 @@
+---
+name: kemal-database
+description: Database initialization and interaction with SQLite and raw SQL in Kemal, following established project patterns.
+---
+
+# Kemal Database Integration
+
+This skill provides expert guidance on integrating SQLite databases with Kemal using the `db` and `sqlite3` shards, strictly following patterns from `src/kemal-by-example/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| Crystal `crystal-lang/crystal-db` (`db`) | Supported | Supported |
+| SQLite Driver (`crystal-lang/crystal-sqlite3`) | Supported | Supported |
+| Model Serialization (`DB::Serializable`) | Supported | Supported |
+| Connection Pooling & Transactions | Supported | Supported |
+
+## Core Mandates
+
+- **Dependencies:** Always `require "db"` and `require "sqlite3"` in the main application file. Add them to `shard.yml`.
+- **Connection:** Centralize the database connection in a `config/database.cr` file. Use environment variables for the URL:
+
+  ```crystal
+  module MyProject
+    module Database
+      extend self
+      DATABASE_URL = ENV["DATABASE_URL"]? || "sqlite3:./db/database.db"
+
+      @@mutex = Mutex.new
+      @@connection : DB::Database? = nil
+
+      def connection : DB::Database
+        @@connection || @@mutex.synchronize { @@connection ||= DB.open(DATABASE_URL) }
+      end
+    end
+  end
+  ```
+
+- **Schema Setup:** Use a `Schema.setup` method to run `CREATE TABLE IF NOT EXISTS` statements:
+
+  ```crystal
+  module MyProject
+    module Schema
+      extend self
+
+      def setup
+        Database.connection.exec <<-SQL
+          CREATE TABLE IF NOT EXISTS items (
+            id INTEGER PRIMARY KEY,
+            name TEXT NOT NULL,
+            created_at TEXT NOT NULL
+          )
+        SQL
+      end
+    end
+  end
+  ```
+
+- **Model Mapping:** Use `include DB::Serializable` in models for automatic mapping from SQL results:
+
+  ```crystal
+  class Item
+    include DB::Serializable
+    property id : Int64?
+    property name : String
+    property created_at : String
+  end
+  ```
+
+- **Data Retrieval:** Use `query_all` and `query_one?` with the `as: Class` argument:
+  - `Database.connection.query_all("SELECT * FROM items", as: Item)`
+  - `Database.connection.query_one?("SELECT * FROM items WHERE id = ?", id, as: Item)`
+
+## Patterns from Source Code
+
+### Database Module Pattern (All Projects)
+
+```crystal
+# config/database.cr
+module Blog
+  module Database
+    extend self
+
+    DATABASE_URL = ENV["DATABASE_URL"]? || "sqlite3:./db/blog.db"
+
+    @@mutex = Mutex.new
+    @@connection : DB::Database? = nil
+
+    def connection : DB::Database
+      @@connection || @@mutex.synchronize { @@connection ||= DB.open(DATABASE_URL) }
+    end
+  end
+end
+```
+
+### Schema Setup with Multiple Tables
+
+```crystal
+# config/schema.cr
+module Ecommerce
+  module Schema
+    extend self
+
+    def setup
+      Database.connection.exec <<-SQL
+        CREATE TABLE IF NOT EXISTS users (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL,
+          email TEXT NOT NULL UNIQUE,
+          password_hash TEXT NOT NULL,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      SQL
+
+      Database.connection.exec <<-SQL
+        CREATE TABLE IF NOT EXISTS products (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL,
+          description TEXT NOT NULL,
+          price_cents INTEGER NOT NULL,
+          inventory_count INTEGER NOT NULL DEFAULT 0,
+          created_at TEXT NOT NULL,
+          updated_at TEXT NOT NULL
+        )
+      SQL
+    end
+  end
+end
+```
+
+### Model with DB::Serializable
+
+```crystal
+# models/post.cr
+class Post
+  include DB::Serializable
+
+  getter id : Int64?
+  getter title : String
+  getter body : String
+  getter created_at : String
+  getter updated_at : String
+
+  def initialize(
+    @title : String,
+    @body : String,
+    @id : Int64? = nil,
+    @created_at : String = Time.utc.to_s,
+    @updated_at : String = Time.utc.to_s,
+  )
+  end
+
+  def self.all : Array(Post)
+    Blog::Database.connection.query_all(
+      "SELECT id, title, body, created_at, updated_at FROM posts ORDER BY created_at DESC",
+      as: Post
+    )
+  end
+
+  def self.find(id : Int64) : Post?
+    Blog::Database.connection.query_one?(
+      "SELECT id, title, body, created_at, updated_at FROM posts WHERE id = ?",
+      id,
+      as: Post
+    )
+  end
+
+  def self.create(title : String, body : String) : Post
+    now = Time.utc.to_s
+    Blog::Database.connection.exec(
+      "INSERT INTO posts (title, body, created_at, updated_at) VALUES (?, ?, ?, ?)",
+      title,
+      body,
+      now,
+      now
+    )
+    id = Blog::Database.connection.scalar("SELECT last_insert_rowid()").as(Int64)
+    find(id) || raise "Failed to load post ##{id} after creation"
+  end
+
+  def update(title : String, body : String)
+    Blog::Database.connection.exec(
+      "UPDATE posts SET title = ?, body = ?, updated_at = ? WHERE id = ?",
+      title,
+      body,
+      Time.utc.to_s,
+      @id
+    )
+  end
+
+  def delete
+    Blog::Database.connection.exec(
+      "DELETE FROM posts WHERE id = ?",
+      @id
+    )
+  end
+end
+```
+
+### Initialization in Main File
+
+```crystal
+# blog.cr
+require "kemal"
+require "db"
+require "sqlite3"
+
+require "./config/database"
+require "./config/schema"
+require "./models/post"
+require "./routes/home"
+require "./routes/posts"
+
+Blog::Schema.setup
+Kemal.run
+```
+
+## Best Practices
+
+- **Initialization:** Call `Schema.setup` before `Kemal.run` in the main application file.
+- **Timestamps:** Always use `Time.utc.to_s` for storing `created_at` and `updated_at` as `TEXT` in SQLite.
+- **ID Handling:** Use `Int64?` for IDs to accommodate auto-incrementing fields during creation.
+- **Transactions:** Use `Database.connection.transaction do |tx| ... end` for atomic operations.
+- **SQL Execution:** Use `Database.connection.exec("SQL", args)` for insert, update, and delete operations.
+- **Explicit Column Lists:** List all columns explicitly in SELECT statements rather than using `SELECT *`.
+
+## When to Use
+
+- When setting up a new database or modifying an existing schema.
+- When implementing model methods that interact with the database.
+- When configuring database connections and initialization logic.

--- a/.github/skills/kemal-database/SKILL.md
+++ b/.github/skills/kemal-database/SKILL.md
@@ -1,20 +1,12 @@
 ---
 name: kemal-database
 description: Database initialization and interaction with SQLite and raw SQL in Kemal, following established project patterns.
+license: MIT
 ---
 
 # Kemal Database Integration
 
-This skill provides expert guidance on integrating SQLite databases with Kemal using the `db` and `sqlite3` shards, strictly following patterns from `src/kemal-by-example/`.
-
-## Compatibility Matrix
-
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| Crystal `crystal-lang/crystal-db` (`db`) | Supported | Supported |
-| SQLite Driver (`crystal-lang/crystal-sqlite3`) | Supported | Supported |
-| Model Serialization (`DB::Serializable`) | Supported | Supported |
-| Connection Pooling & Transactions | Supported | Supported |
+This skill provides expert guidance on integrating SQLite databases with Kemal using the `db` and `sqlite3` shards, strictly following patterns from [`kemal-by-example`](https://github.com/sdogruyol/kemal-by-example).
 
 ## Core Mandates
 
@@ -169,14 +161,17 @@ class Post
 
   def self.create(title : String, body : String) : Post
     now = Time.utc.to_s
-    Blog::Database.connection.exec(
+    # `Database.connection` is a pooled `DB::Database`: a separate
+    # `SELECT last_insert_rowid()` may run on a different connection and return
+    # the wrong id. Read the id from the `DB::ExecResult` of the INSERT itself.
+    result = Blog::Database.connection.exec(
       "INSERT INTO posts (title, body, created_at, updated_at) VALUES (?, ?, ?, ?)",
       title,
       body,
       now,
       now
     )
-    id = Blog::Database.connection.scalar("SELECT last_insert_rowid()").as(Int64)
+    id = result.last_insert_id
     find(id) || raise "Failed to load post ##{id} after creation"
   end
 

--- a/.github/skills/kemal-json/SKILL.md
+++ b/.github/skills/kemal-json/SKILL.md
@@ -1,21 +1,17 @@
 ---
 name: kemal-json
 description: Building JSON APIs with Kemal using built-in response helpers and established project patterns.
+license: MIT
 ---
 
 # Kemal JSON API Development
 
-This skill provides expert guidance on building robust JSON APIs with Kemal, establishing the canonical patterns for JSON response helpers and strictly following patterns from `src/kemal-by-example/json-api/`.
+This skill provides expert guidance on building robust JSON APIs with Kemal, establishing the canonical patterns for JSON response helpers and strictly following patterns from [`kemal-by-example/json-api`](https://github.com/sdogruyol/kemal-by-example/tree/master/json-api).
 
-## Compatibility Matrix
+## Version Notes
 
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `env.json(payload)` Response Helper | Supported (1.10+) | Supported |
-| `env.status(:symbol)` Status Helper | Supported (1.10+) | Supported |
-| `env.params.raw_body` Safe Parsing | Supported | Supported |
-| Symbol Status Mapping (`:ok`, `:created`, etc.) | Supported | Supported |
-| Malformed Body 400 Response (Auto-handling) | Returns 500 | Supported (400 Bad Request) |
+- `env.json` and `env.status` response helpers (symbol or integer statuses): since Kemal 1.10.
+- Malformed request bodies (e.g. invalid JSON) are answered with `400 Bad Request` on Kemal master; earlier releases return `500`.
 
 ## Core Mandates
 

--- a/.github/skills/kemal-json/SKILL.md
+++ b/.github/skills/kemal-json/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: kemal-json
+description: Building JSON APIs with Kemal using built-in response helpers and established project patterns.
+---
+
+# Kemal JSON API Development
+
+This skill provides expert guidance on building robust JSON APIs with Kemal, establishing the canonical patterns for JSON response helpers and strictly following patterns from `src/kemal-by-example/json-api/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `env.json(payload)` Response Helper | Supported (1.10+) | Supported |
+| `env.status(:symbol)` Status Helper | Supported (1.10+) | Supported |
+| `env.params.raw_body` Safe Parsing | Supported | Supported |
+| Symbol Status Mapping (`:ok`, `:created`, etc.) | Supported | Supported |
+| Malformed Body 400 Response (Auto-handling) | Returns 500 | Supported (400 Bad Request) |
+
+## Core Mandates
+
+- **Dependencies:** Always `require "json"`.
+- **Built-in Context Response Helpers (Kemal 1.10+):** Use Kemal's built-in `env.json` and status helpers for API responses:
+
+  ```crystal
+  # Basic JSON response (sets Content-Type to application/json; charset=utf-8 automatically)
+  get "/api/users" do |env|
+    env.json({users: %w[alice bob]})
+  end
+
+  # Symbol or integer HTTP status code with JSON:
+  post "/api/users" do |env|
+    env.status(:created).json({id: 1, name: "Alice"})
+  end
+
+  # Early halt with JSON:
+  get "/api/protected" do |env|
+    halt env.status(:unauthorized).json({error: "Unauthorized"}) unless authenticated?(env)
+  end
+  ```
+
+- **Project JsonResponse Helpers (Custom Pattern):** When using standard project helpers for responses (found in `JsonApi::JsonResponse`):
+
+  ```crystal
+  module JsonApi
+    module JsonResponse
+      extend self
+
+      def json(env : HTTP::Server::Context, status : Int32, payload : String)
+        env.response.status_code = status
+        env.response.content_type = "application/json; charset=utf-8"
+        payload
+      end
+
+      def error(env : HTTP::Server::Context, status : Int32, message : String)
+        json(env, status, {"error" => message}.to_json)
+      end
+    end
+  end
+  ```
+
+- **Safe JSON Body Parsing:** Use `env.params.raw_body` or `read_json_object(env)` to safely parse JSON bodies and handle exceptions:
+
+  ```crystal
+  private def read_json_object(env : HTTP::Server::Context) : Hash(String, JSON::Any)?
+    raw = env.params.raw_body
+    return nil if raw.strip.empty?
+    parsed = JSON.parse(raw)
+    parsed.as_h?
+  rescue JSON::ParseException
+    nil
+  end
+  ```
+
+- **Serialization:** Models should provide a `to_h` method. Use `model.to_h` or `model.to_h.to_json` for responses.
+
+## Patterns from Source Code
+
+### API Routes with Full CRUD (json-api/src/routes/api.cr)
+
+```crystal
+require "json"
+require "../helpers/json_response"
+require "../models/note"
+
+private def read_json_object(env : HTTP::Server::Context) : Hash(String, JSON::Any)?
+  raw = env.params.raw_body
+  return nil if raw.strip.empty?
+  parsed = JSON.parse(raw)
+  parsed.as_h?
+rescue JSON::ParseException
+  nil
+end
+
+private def note_id(env : HTTP::Server::Context) : Int64?
+  env.params.url["id"]?.try(&.to_i64?)
+end
+
+private def string_field(h : Hash(String, JSON::Any), key : String) : String?
+  h[key]?.try(&.as_s?)
+end
+
+get "/api/notes" do |env|
+  list = Note.all.map(&.to_h)
+  env.json({"notes" => list})
+end
+
+get "/api/notes/:id" do |env|
+  id = note_id(env)
+  unless id
+    halt env.status(:bad_request).json({"error" => "invalid id"})
+  end
+
+  note = Note.find(id)
+  if note
+    env.json(note.to_h)
+  else
+    env.status(:not_found).json({"error" => "note not found"})
+  end
+end
+
+post "/api/notes" do |env|
+  obj = read_json_object(env)
+  unless obj
+    halt env.status(:bad_request).json({"error" => "expected JSON object body"})
+  end
+
+  title = string_field(obj, "title").try(&.strip) || ""
+  if title.empty?
+    halt env.status(:unprocessable_entity).json({"error" => "title is required"})
+  end
+
+  body = string_field(obj, "body").try(&.strip) || ""
+  new_id = Note.create(title, body)
+  note = Note.find(new_id)
+
+  if note
+    env.status(:created).json(note.to_h)
+  else
+    env.status(:internal_server_error).json({"error" => "failed to load created note"})
+  end
+end
+
+delete "/api/notes/:id" do |env|
+  id = note_id(env)
+  unless id
+    halt env.status(:bad_request).json({"error" => "invalid id"})
+  end
+
+  note = Note.find(id)
+  unless note
+    halt env.status(:not_found).json({"error" => "note not found"})
+  end
+
+  note.delete
+  env.status(:no_content)
+end
+```
+
+## Best Practices
+
+- **Use Context Response Helpers:** Leverage `env.json` and `env.status(...)` for idiomatic, chainable response handling.
+- **Consistent Error Format:** Always return a JSON object with an `error` key for failure states.
+- **Safe Field Access:** Use `obj[key]?.try(&.as_s?)` or similar safe accessors for fields in parsed JSON hashes.
+- **Input Validation:** Rigorously validate required fields and types before processing the request.
+- **Status Symbols:** Use standard status symbols like `:ok`, `:created`, `:no_content`, `:bad_request`, `:unauthorized`, `:not_found`, `:unprocessable_entity`.
+
+## When to Use
+
+- When developing or refactoring API routes that return JSON.
+- When handling JSON body parameters from client requests.
+- When implementing standardized JSON error handling.

--- a/.github/skills/kemal-middleware/SKILL.md
+++ b/.github/skills/kemal-middleware/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: kemal-middleware
+description: Creating and using custom middleware in Kemal using modern `use` keyword and handler classes.
+---
+
+# Kemal Middleware & Handlers
+
+This skill provides expert guidance on creating and using custom middleware in Kemal, leveraging modern `use` registration and filter macros, strictly following patterns from `src/kemal-by-example/webhook-inbox/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `use` Keyword Registration | Supported (1.10+) | Supported |
+| Path-Scoped `use "/api", [handlers]` | Supported (1.10+) | Supported |
+| `Kemal::Handler` Inheritance & `call_next` | Supported | Supported |
+| `only` / `exclude` Filtering with `*` & Globs | Supported (1.12.0+) | Supported |
+| Auth Middleware Scope Fix (Prefix matching) | Partial | Supported (strict prefix check) |
+
+## Core Mandates
+
+- **Middleware Registration (`use` Keyword in Kemal 1.10+):** Prefer `use` for clean global or path-scoped middleware registration:
+
+  ```crystal
+  # Path-scoped middleware (applies only to /api routes)
+  use "/api", [CORSHandler.new, AuthHandler.new]
+
+  # Global middleware (applies to all routes)
+  use CustomHandler.new
+  ```
+
+- **Configuration-based Registration:** Alternatively, use `Kemal.config.add_handler(CustomHandler.new)`. (The bare top-level `add_handler` is deprecated in favor of `use` and `Kemal.config.add_handler`).
+
+- **Handlers:** Create custom middleware by inheriting from `Kemal::Handler`:
+
+  ```crystal
+  class MyHandler < Kemal::Handler
+    def call(context)
+      # Execution prior to next handler
+      call_next(context)
+      # Execution after next handler returns
+    end
+  end
+  ```
+
+- **Selective Filtering in Handlers:** Use `only` or `exclude` macros to restrict execution within the handler class. Supports specific verbs, all verbs (`"*"`), and path prefix globs (`"/*"`):
+
+  ```crystal
+  class MyHandler < Kemal::Handler
+    # Matches all HTTP methods on /admin and sub-paths
+    only %w[/admin/*], "*"
+
+    def call(context)
+      return call_next(context) unless only_match?(context)
+      # Custom logic
+      call_next(context)
+    end
+  end
+  ```
+
+- **Legacy Registration (`add_handler`):** `add_handler MyHandler.new` remains supported for backward compatibility.
+
+- **Specialized Handlers (HMAC):** For HMAC signatures, `require "kemal-hmac"` and inherit from `Kemal::Hmac::Handler`:
+
+  ```crystal
+  class InboxHmacHandler < Kemal::Hmac::Handler
+    only %w[/hooks/inbox], "POST"
+
+    def call(context)
+      return call_next(context) unless only_match?(context)
+      super
+    end
+  end
+  ```
+
+## Patterns from Source Code
+
+### HMAC Handler (webhook-inbox/src/middleware/inbox_hmac_handler.cr)
+
+```crystal
+require "kemal-hmac"
+
+# Protects only `POST /hooks/inbox` with kemal-hmac.
+class WebhookInbox::InboxHmacHandler < Kemal::Hmac::Handler
+  only %w[/hooks/inbox], "POST"
+
+  def call(context)
+    return call_next(context) unless only_match?(context)
+    super
+  end
+end
+```
+
+### Main Application Setup (webhook-inbox/src/webhook_inbox.cr)
+
+```crystal
+require "kemal"
+require "kemal-hmac"
+require "db"
+require "sqlite3"
+
+require "./config/app"
+require "./config/database"
+require "./config/schema"
+require "./helpers/headers_json"
+require "./middleware/inbox_hmac_handler"
+require "./models/webhook_event"
+require "./routes/home"
+require "./routes/inbox"
+require "./routes/events"
+
+# Configure HMAC handler with client/secret mapping and use keyword
+client = WebhookInbox.webhook_client
+use WebhookInbox::InboxHmacHandler.new({client => [WebhookInbox.webhook_secret]})
+
+WebhookInbox::Schema.setup
+Kemal.run
+```
+
+## Best Practices
+
+- **Use Keyword:** Prefer `use "/path", Handler.new` for path-scoped middleware instead of checking path conditions inside route blocks.
+- **Minimalist Design:** Keep handlers focused on a single responsibility (e.g., CORS, logging, authorization).
+- **Execution Order:** Order middleware intentionally (e.g., authentication handlers must run before route handlers that depend on auth context).
+- **HMAC Setup:** For `Kemal::Hmac::Handler`, pass key/secret maps as `{ "client_id" => ["secret_key"] }`.
+
+## When to Use
+
+- When implementing cross-cutting concerns (authentication, CORS, security headers, logging).
+- When protecting specific API routes using HMAC or token authorization.
+- When organizing global or path-scoped request processing stacks.

--- a/.github/skills/kemal-middleware/SKILL.md
+++ b/.github/skills/kemal-middleware/SKILL.md
@@ -1,21 +1,18 @@
 ---
 name: kemal-middleware
 description: Creating and using custom middleware in Kemal using modern `use` keyword and handler classes.
+license: MIT
 ---
 
 # Kemal Middleware & Handlers
 
-This skill provides expert guidance on creating and using custom middleware in Kemal, leveraging modern `use` registration and filter macros, strictly following patterns from `src/kemal-by-example/webhook-inbox/`.
+This skill provides expert guidance on creating and using custom middleware in Kemal, leveraging modern `use` registration and filter macros, strictly following patterns from [`kemal-by-example/webhook-inbox`](https://github.com/sdogruyol/kemal-by-example/tree/master/webhook-inbox).
 
-## Compatibility Matrix
+## Version Notes
 
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `use` Keyword Registration | Supported (1.10+) | Supported |
-| Path-Scoped `use "/api", [handlers]` | Supported (1.10+) | Supported |
-| `Kemal::Handler` Inheritance & `call_next` | Supported | Supported |
-| `only` / `exclude` Filtering with `*` & Globs | Supported (1.12.0+) | Supported |
-| Auth Middleware Scope Fix (Prefix matching) | Partial | Supported (strict prefix check) |
+- `use` registration (global and path-scoped): since Kemal 1.10.
+- `only` / `exclude` with a single method and exact paths: all supported versions.
+- `only` / `exclude` with `"*"` methods and `"/*"` path globs: Kemal master only — do **not** use the glob syntax on 1.12.0 or earlier, where it matches every path (see the warning below).
 
 ## Core Mandates
 
@@ -43,12 +40,11 @@ This skill provides expert guidance on creating and using custom middleware in K
   end
   ```
 
-- **Selective Filtering in Handlers:** Use `only` or `exclude` macros to restrict execution within the handler class. Supports specific verbs, all verbs (`"*"`), and path prefix globs (`"/*"`):
+- **Selective Filtering in Handlers:** Use `only` or `exclude` macros to restrict execution within the handler class. On Kemal 1.12.0 they support a single HTTP method and exact paths only:
 
   ```crystal
   class MyHandler < Kemal::Handler
-    # Matches all HTTP methods on /admin and sub-paths
-    only %w[/admin/*], "*"
+    only %w[/admin], "POST"
 
     def call(context)
       return call_next(context) unless only_match?(context)
@@ -57,6 +53,19 @@ This skill provides expert guidance on creating and using custom middleware in K
     end
   end
   ```
+
+  On Kemal master, `"*"` matches all methods and paths ending in `"/*"` match a prefix:
+
+  ```crystal
+  # Kemal master only:
+  class MyHandler < Kemal::Handler
+    # Matches all HTTP methods on /admin and sub-paths
+    only %w[/admin/*], "*"
+    # ...
+  end
+  ```
+
+  **WARNING:** Do not use `"*"` or `"/*"` globs on Kemal 1.12.0. The 1.12.0 route matcher treats `*` as a radix glob, so a rule like `only %w[/admin/*], "*"` matches **every path on every method** — an auth handler scoped this way locks the whole site. For middleware that should cover an entire path subtree on any version, prefer `use "/admin", MyHandler.new` instead.
 
 - **Legacy Registration (`add_handler`):** `add_handler MyHandler.new` remains supported for backward compatibility.
 

--- a/.github/skills/kemal-oauth/SKILL.md
+++ b/.github/skills/kemal-oauth/SKILL.md
@@ -1,23 +1,16 @@
 ---
 name: kemal-oauth
 description: Implementing OAuth2 authentication in Kemal, following established project patterns.
+license: MIT
 ---
 
 # Kemal OAuth2 Integration
 
-This skill provides expert guidance on integrating OAuth2 authentication (e.g., GitHub, Google) into Kemal applications, strictly following patterns from `src/kemal-by-example/oauth-login/`.
-
-## Compatibility Matrix
-
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `HTTP::Client` & `URI::Params` Integration | Supported | Supported |
-| CSRF State via `kemal-session` | Supported | Supported |
-| OAuth2 Token Exchange & API Profile Fetch | Supported | Supported |
-| Standard Flow Redirection & Halting | Supported | Supported |
+This skill provides expert guidance on integrating OAuth2 authentication (e.g., GitHub, Google) into Kemal applications, strictly following patterns from [`kemal-by-example/oauth-login`](https://github.com/sdogruyol/kemal-by-example/tree/master/oauth-login).
 
 ## Core Mandates
 
+- **Dependencies:** The route examples below use `env.session` and `env.flash`, both provided by [`kemal-session`](https://github.com/kemalcr/kemal-session) (`env.flash` since kemal-session 1.4.0). Add it to `shard.yml` and `require "kemal-session"`.
 - **Configuration:** Use environment variables for client IDs and secrets:
 
   ```crystal
@@ -170,6 +163,8 @@ end
 ```
 
 ### OAuth Routes (oauth-login/src/routes/oauth.cr)
+
+`env.flash` below is kemal-session's one-time flash message helper (see Dependencies above).
 
 ```crystal
 require "random"

--- a/.github/skills/kemal-oauth/SKILL.md
+++ b/.github/skills/kemal-oauth/SKILL.md
@@ -1,0 +1,224 @@
+---
+name: kemal-oauth
+description: Implementing OAuth2 authentication in Kemal, following established project patterns.
+---
+
+# Kemal OAuth2 Integration
+
+This skill provides expert guidance on integrating OAuth2 authentication (e.g., GitHub, Google) into Kemal applications, strictly following patterns from `src/kemal-by-example/oauth-login/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `HTTP::Client` & `URI::Params` Integration | Supported | Supported |
+| CSRF State via `kemal-session` | Supported | Supported |
+| OAuth2 Token Exchange & API Profile Fetch | Supported | Supported |
+| Standard Flow Redirection & Halting | Supported | Supported |
+
+## Core Mandates
+
+- **Configuration:** Use environment variables for client IDs and secrets:
+
+  ```crystal
+  def client_id : String
+    ENV["GITHUB_CLIENT_ID"]? || ""
+  end
+
+  def client_secret : String
+    ENV["GITHUB_CLIENT_SECRET"]? || ""
+  end
+
+  def redirect_uri : String
+    ENV["OAUTH_REDIRECT_URI"]? || "http://127.0.0.1:3000/auth/github/callback"
+  end
+  ```
+
+- **Authorization URL:** Use `URI::Params` to construct the authorization URL with required scopes and a state parameter:
+
+  ```crystal
+  def authorize_url(state : String) : String
+    params = URI::Params.build do |form|
+      form.add "client_id", client_id
+      form.add "redirect_uri", redirect_uri
+      form.add "scope", "read:user user:email"
+      form.add "state", state
+    end
+    "https://github.com/login/oauth/authorize?#{params}"
+  end
+  ```
+
+- **State Parameter:** Generate state with `Random::Secure.random_bytes(16).hexstring`, store in `env.session`, verify in callback, then delete:
+
+  ```crystal
+  # In authorization route:
+  state = Random::Secure.random_bytes(16).hexstring
+  env.session.string("oauth_state", state)
+
+  # In callback:
+  stored = env.session.string?("oauth_state")
+  env.session.delete_string("oauth_state")
+  halt env.status(:forbidden) unless state == stored
+  ```
+
+- **Exchanging Code:** Use `HTTP::Client` to exchange the authorization code for an access token. Always set `Accept`, `Content-Type`, and `User-Agent` headers:
+
+  ```crystal
+  response = HTTP::Client.post(
+    "https://github.com/login/oauth/access_token",
+    headers: HTTP::Headers{
+      "Accept"       => "application/json",
+      "Content-Type" => "application/x-www-form-urlencoded",
+      "User-Agent"   => "my-app",
+    },
+    body: URI::Params.encode({
+      "client_id"     => client_id,
+      "client_secret" => client_secret,
+      "code"          => code,
+      "redirect_uri"  => redirect_uri,
+    })
+  )
+  return nil unless response.success?
+  json = JSON.parse(response.body)
+  json["access_token"]?.try(&.as_s?)
+  rescue JSON::ParseException
+    nil
+  ```
+
+## Patterns from Source Code
+
+### OAuth Service Module (oauth-login/src/services/github_oauth.cr)
+
+```crystal
+require "http/client"
+require "json"
+require "uri"
+
+module OauthLogin
+  module GithubOauth
+    extend self
+
+    USER_AGENT = "kemal-oauth-login"
+
+    def client_id : String
+      ENV["GITHUB_CLIENT_ID"]? || ""
+    end
+
+    def client_secret : String
+      ENV["GITHUB_CLIENT_SECRET"]? || ""
+    end
+
+    def redirect_uri : String
+      ENV["OAUTH_REDIRECT_URI"]? || "http://127.0.0.1:3000/auth/github/callback"
+    end
+
+    def configured? : Bool
+      !client_id.empty? && !client_secret.empty?
+    end
+
+    def authorize_url(state : String) : String
+      params = URI::Params.build do |form|
+        form.add "client_id", client_id
+        form.add "redirect_uri", redirect_uri
+        form.add "scope", "read:user user:email"
+        form.add "state", state
+      end
+      "https://github.com/login/oauth/authorize?#{params}"
+    end
+
+    def exchange_code(code : String) : String?
+      body = URI::Params.encode({
+        "client_id"     => client_id,
+        "client_secret" => client_secret,
+        "code"          => code,
+        "redirect_uri"  => redirect_uri,
+      })
+      response = HTTP::Client.post(
+        "https://github.com/login/oauth/access_token",
+        headers: HTTP::Headers{
+          "Accept"       => "application/json",
+          "Content-Type" => "application/x-www-form-urlencoded",
+          "User-Agent"   => USER_AGENT,
+        },
+        body: body
+      )
+      return nil unless response.success?
+
+      json = JSON.parse(response.body)
+      json["access_token"]?.try(&.as_s?)
+    rescue JSON::ParseException
+      nil
+    end
+
+    def fetch_github_user(access_token : String) : Hash(String, JSON::Any)?
+      response = HTTP::Client.get(
+        "https://api.github.com/user",
+        headers: HTTP::Headers{
+          "Authorization" => "Bearer #{access_token}",
+          "Accept"        => "application/vnd.github+json",
+          "User-Agent"    => USER_AGENT,
+        }
+      )
+      return nil unless response.success?
+
+      JSON.parse(response.body).as_h?
+    rescue JSON::ParseException
+      nil
+    end
+  end
+end
+```
+
+### OAuth Routes (oauth-login/src/routes/oauth.cr)
+
+```crystal
+require "random"
+
+get "/auth/github" do |env|
+  unless OauthLogin::GithubOauth.configured?
+    env.flash["error"] = "Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET. See README."
+    env.redirect "/"
+    next
+  end
+
+  state = Random::Secure.random_bytes(16).hexstring
+  env.session.string("oauth_state", state)
+  env.redirect OauthLogin::GithubOauth.authorize_url(state)
+end
+
+get "/auth/github/callback" do |env|
+  code = env.params.query["code"]?
+  state = env.params.query["state"]?
+  stored = env.session.string?("oauth_state")
+  env.session.delete_string("oauth_state")
+
+  unless code && state && stored && state == stored
+    env.flash["error"] = "OAuth state mismatch or missing code."
+    env.redirect "/"
+    next
+  end
+
+  token = OauthLogin::GithubOauth.exchange_code(code)
+  unless token
+    env.flash["error"] = "Could not exchange code for token."
+    env.redirect "/"
+    next
+  end
+
+  # ... fetch user, sign in, redirect
+end
+```
+
+## Best Practices
+
+- **Service Isolation:** Encapsulate OAuth logic within dedicated service modules (e.g., `GithubOauth`).
+- **Error Handling:** Gracefully handle API errors and JSON parsing failures during the OAuth flow using specific exception types.
+- **Session Security:** Use `env.session` for state management throughout the OAuth lifecycle. Always clean up state after verification.
+- **Profile Fetching:** Use the access token to fetch user profile information using `HTTP::Client` with appropriate `Authorization: Bearer` headers.
+- **Configured Check:** Check if OAuth is configured before redirecting to avoid errors.
+
+## When to Use
+
+- When implementing "Login with GitHub/Google" features.
+- When interacting with external APIs that require OAuth2 authentication.
+- When managing OAuth flows and callbacks in a Kemal application.

--- a/.github/skills/kemal-orm/SKILL.md
+++ b/.github/skills/kemal-orm/SKILL.md
@@ -1,0 +1,242 @@
+---
+name: kemal-orm
+description: Object-Relational Mapping (ORM) with Crecto and SQLite in Kemal, following established project patterns.
+---
+
+# Kemal ORM Integration (Crecto)
+
+This skill provides expert guidance on using Crecto ORM with Kemal applications and SQLite, strictly following patterns from `src/kemal-by-example/budget-management-orm/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| Crecto ORM (`crecto`) Integration | Supported | Supported |
+| Crecto Adapters (`Crecto::Adapters::SQLite3`) | Supported | Supported |
+| Declarative Schema, Validations & Queries | Supported | Supported |
+| Centwise Integer Currency Handling | Supported | Supported |
+
+## Core Mandates
+
+- **Dependencies:** Include `kemal`, `crecto`, and `sqlite3` in `shard.yml` and `require` them in the main application file.
+- **Repository Setup:** Centralize Crecto configuration in a `config/repo.cr` module:
+
+  ```crystal
+  module MyProject
+    module Repo
+      extend Crecto::Repo
+
+      config do |conf|
+        conf.adapter = Crecto::Adapters::SQLite3
+        conf.db = ENV["DATABASE_URL"]? || "sqlite3:./db/app.db"
+      end
+    end
+  end
+  ```
+
+- **Schema Initialization:** Set up database schema tables with `Repo.db_adapter.exec` in a `Schema.setup` module:
+
+  ```crystal
+  module MyProject
+    module Schema
+      extend self
+
+      def setup
+        Repo.db_adapter.exec <<-SQL
+          CREATE TABLE IF NOT EXISTS budget_entries (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT NOT NULL,
+            kind TEXT NOT NULL,
+            amount_cents INTEGER NOT NULL,
+            notes TEXT NOT NULL DEFAULT '',
+            created_at DATETIME,
+            updated_at DATETIME
+          );
+        SQL
+      end
+    end
+  end
+  ```
+
+- **Model Definition:** Subclass `Crecto::Model`, declare fields inside `schema`, and set validation rules:
+
+  ```crystal
+  module MyProject
+    class BudgetEntry < Crecto::Model
+      schema "budget_entries" do
+        field :title, String
+        field :kind, String
+        field :amount_cents, Int64
+        field :notes, String
+      end
+
+      validate_required :title
+      validate_inclusion :kind, %w[income expense]
+    end
+  end
+  ```
+
+- **Repository Operations:**
+  - Querying all: `query = Crecto::Repo::Query.new.order_by("id DESC"); Repo.all(BudgetEntry, query)`
+  - Finding by ID: `Repo.get(BudgetEntry, id)`
+  - Creating: `entry = BudgetEntry.new; entry.title = title; Repo.insert(entry)`
+  - Updating: `entry.title = new_title; Repo.update(entry)`
+  - Deleting: `Repo.delete(entry)`
+
+## Patterns from Source Code
+
+### Repo Configuration (`config/repo.cr`)
+
+```crystal
+require "crecto"
+
+module BudgetManagementOrm
+  module Repo
+    extend Crecto::Repo
+
+    config do |conf|
+      conf.adapter = Crecto::Adapters::SQLite3
+      conf.db = ENV["DATABASE_URL"]? || "sqlite3:./db/budget.db"
+    end
+  end
+end
+```
+
+### Schema Setup (`config/schema.cr`)
+
+```crystal
+require "./repo"
+
+module BudgetManagementOrm
+  module Schema
+    extend self
+
+    def setup
+      Repo.db_adapter.exec <<-SQL
+        CREATE TABLE IF NOT EXISTS budget_entries (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          title TEXT NOT NULL,
+          kind TEXT NOT NULL,
+          amount_cents INTEGER NOT NULL,
+          notes TEXT NOT NULL DEFAULT '',
+          created_at DATETIME,
+          updated_at DATETIME
+        );
+      SQL
+    end
+  end
+end
+```
+
+### Model with Validations & Domain Logic (`models/budget_entry.cr`)
+
+```crystal
+require "../config/repo"
+
+module BudgetManagementOrm
+  class BudgetEntry < Crecto::Model
+    schema "budget_entries" do
+      field :title, String
+      field :kind, String
+      field :amount_cents, Int64
+      field :notes, String
+    end
+
+    validate_required :title
+    validate_inclusion :kind, %w[income expense]
+
+    def income? : Bool
+      kind == "income"
+    end
+
+    def expense? : Bool
+      kind == "expense"
+    end
+
+    def self.all_ordered : Array(BudgetEntry)
+      query = Crecto::Repo::Query.new.order_by("id DESC")
+      Repo.all(BudgetEntry, query)
+    end
+
+    def self.find(id : Int64) : BudgetEntry?
+      Repo.get(BudgetEntry, id)
+    end
+
+    def self.create(title : String, kind : String, notes : String, amount_cents : Int64)
+      entry = BudgetEntry.new
+      entry.title = title
+      entry.kind = kind
+      entry.notes = notes
+      entry.amount_cents = amount_cents
+      Repo.insert(entry)
+    end
+
+    def update_fields(title : String, kind : String, notes : String, amount_cents : Int64)
+      self.title = title
+      self.kind = kind
+      self.notes = notes
+      self.amount_cents = amount_cents
+      Repo.update(self)
+    end
+
+    def destroy
+      Repo.delete(self)
+    end
+  end
+end
+```
+
+### Route Integration with Crecto Models (`routes/entries.cr`)
+
+```crystal
+get "/entries" do
+  entries = BudgetManagementOrm::BudgetEntry.all_ordered
+  render "src/views/entries/index.ecr", "src/views/layouts/application.ecr"
+end
+
+get "/entries/:id/edit" do |env|
+  id = env.params.url["id"]?.try(&.to_i64?)
+  entry = id ? BudgetManagementOrm::BudgetEntry.find(id) : nil
+
+  if entry
+    render "src/views/entries/edit.ecr", "src/views/layouts/application.ecr"
+  else
+    env.response.status = :not_found
+    "Entry not found"
+  end
+end
+
+post "/entries" do |env|
+  title = env.params.body["title"]?.try(&.strip) || ""
+  raw_kind = env.params.body["kind"]? || "expense"
+  kind = raw_kind == "income" ? "income" : "expense"
+  notes = env.params.body["notes"]?.try(&.strip) || ""
+  cents = BudgetManagementOrm::Money.parse_cents(env.params.body["amount"]? || "")
+
+  if !title.empty? && cents && cents > 0
+    BudgetManagementOrm::BudgetEntry.create(title, kind, notes, cents)
+  end
+
+  env.redirect "/entries"
+end
+
+post "/entries/:id/delete" do |env|
+  id = env.params.url["id"]?.try(&.to_i64?)
+  entry = id ? BudgetManagementOrm::BudgetEntry.find(id) : nil
+  entry.try(&.destroy)
+  env.redirect "/entries"
+end
+```
+
+## Best Practices
+
+- **Centwise Currency Storage:** Always store monetary values as integers (`Int64` cents) to avoid floating-point rounding errors.
+- **Repository Pattern:** Delegate database access to Crecto's `Repo` object rather than executing raw SQL strings directly in route handlers.
+- **Model Validation:** Use `validate_required`, `validate_format`, and `validate_inclusion` inside model definitions for declarative data integrity.
+- **Initialization Order:** Run `Schema.setup` in your main entrypoint file before calling `Kemal.run`.
+
+## When to Use
+
+- When building Kemal applications that require ORM abstraction (Crecto) instead of raw SQL strings.
+- When organizing complex domain models with validations and relations.
+- When managing structured database queries with ordering, filtering, and transactions.

--- a/.github/skills/kemal-orm/SKILL.md
+++ b/.github/skills/kemal-orm/SKILL.md
@@ -1,20 +1,12 @@
 ---
 name: kemal-orm
 description: Object-Relational Mapping (ORM) with Crecto and SQLite in Kemal, following established project patterns.
+license: MIT
 ---
 
 # Kemal ORM Integration (Crecto)
 
-This skill provides expert guidance on using Crecto ORM with Kemal applications and SQLite, strictly following patterns from `src/kemal-by-example/budget-management-orm/`.
-
-## Compatibility Matrix
-
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| Crecto ORM (`crecto`) Integration | Supported | Supported |
-| Crecto Adapters (`Crecto::Adapters::SQLite3`) | Supported | Supported |
-| Declarative Schema, Validations & Queries | Supported | Supported |
-| Centwise Integer Currency Handling | Supported | Supported |
+This skill provides expert guidance on using Crecto ORM with Kemal applications and SQLite, strictly following patterns from [`kemal-by-example/budget-management-orm`](https://github.com/sdogruyol/kemal-by-example/tree/master/budget-management-orm).
 
 ## Core Mandates
 

--- a/.github/skills/kemal-sse/SKILL.md
+++ b/.github/skills/kemal-sse/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: kemal-sse
+description: Real-time Server-Sent Events (SSE) streaming in Kemal 1.12+, following established project patterns.
+---
+
+# Kemal Server-Sent Events (SSE)
+
+This skill provides expert guidance on implementing real-time unidirectional event streaming using Kemal's built-in `sse` helper (available in Kemal 1.12.0+).
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `sse` Route Helper & `Kemal::EventStream` | Supported (1.12.0+) | Supported |
+| Named Events (`event:`, `id:`, `retry:`) | Supported | Supported |
+| Automatic `text/event-stream` Headers | Supported | Supported |
+| Newline Injection Protection & CRLF Normalization | **Not available** | Supported (prevents SSE header/event injection) |
+| `retry` Field Int32 Overflow Fix | **Not available** | Supported |
+
+## Core Mandates
+
+- **SSE Route Definition (Kemal 1.12.0+):** Use the `sse` helper block to define an SSE endpoint:
+
+  ```crystal
+  sse "/events" do |stream, env|
+    stream.send("hello world")
+  end
+  ```
+
+- **Sending Named Events & Security:** Pass `event`, `id`, and optional `retry` (`Time::Span`) keyword arguments:
+
+  ```crystal
+  sse "/notifications" do |stream, env|
+    stream.send({"message" => "New alert"}.to_json, event: "alert", id: 101, retry: 5.seconds)
+  end
+  ```
+
+  *Security Note (Kemal Master)*: `Kemal::EventStream` on master prevents SSE injection by rejecting raw newlines in `event` and `id` arguments, and automatically normalizes CRLF sequences in `data` and `comment`.
+
+- **Streaming Loops & Channels:** Use Crystal channels or keep-alive loops for streaming events:
+
+  ```crystal
+  sse "/stream" do |stream, env|
+    loop do
+      sleep 1.seconds
+      stream.send(Time.utc.to_s, event: "time")
+    rescue IO::Error
+      break # Connection closed by client
+    end
+  end
+  ```
+
+## Patterns from Source Code
+
+### Real-Time Live Updates with Channel / Loop
+
+```crystal
+require "kemal"
+
+sse "/live-ticks" do |stream, env|
+  count = 0_i64
+  loop do
+    count += 1
+    stream.send(
+      {"count" => count, "timestamp" => Time.utc.to_s}.to_json,
+      event: "tick",
+      id: count
+    )
+    sleep 1.seconds
+  rescue IO::Error
+    # Client disconnected, gracefully terminate streaming loop
+    break
+  end
+end
+
+Kemal.run
+```
+
+### Pub/Sub Broadcasting via SSE Stream Manager
+
+```crystal
+require "kemal"
+
+class SseHub
+  @streams = Array(Kemal::EventStream).new
+  @mutex = Mutex.new
+
+  def register(stream : Kemal::EventStream)
+    @mutex.synchronize { @streams << stream }
+  end
+
+  def unregister(stream : Kemal::EventStream)
+    @mutex.synchronize { @streams.delete(stream) }
+  end
+
+  def broadcast(data : String, event : String? = nil)
+    @mutex.synchronize do
+      @streams.reject! do |stream|
+        begin
+          stream.send(data, event: event)
+          false
+        rescue IO::Error
+          true # Remove closed connections
+        end
+      end
+    end
+  end
+end
+
+HUB = SseHub.new
+
+sse "/subscribe" do |stream, env|
+  HUB.register(stream)
+  # Block while connection remains open
+  begin
+    sleep
+  ensure
+    HUB.unregister(stream)
+  end
+end
+
+post "/publish" do |env|
+  message = env.params.body["message"]? || ""
+  HUB.broadcast(message, event: "news")
+  env.json({status: "ok"})
+end
+
+Kemal.run
+```
+
+## Best Practices
+
+- **Connection Cleanup:** Always handle client disconnects gracefully by rescuing `IO::Error` or using an `ensure` block.
+- **Content Type:** Kemal automatically sets `Content-Type: text/event-stream` and `Cache-Control: no-cache` headers for SSE routes.
+- **JSON Serialization:** Convert Crystal data structures to JSON strings using `.to_json` before passing to `stream.send(...)`.
+- **API Response Helpers:** For JSON response formatting and error handling on companion HTTP routes (e.g. `post "/publish"`), follow the patterns in [`kemal-json`](../kemal-json/SKILL.md).
+- **Prefer SSE over WebSockets for Uni-directional Feeds:** Use SSE for live log feeds, dashboard metrics, and notifications where full bi-directional socket protocol overhead is unnecessary.
+
+## When to Use
+
+- When building real-time dashboards, log streaming, or live notification feeds.
+- When client-to-server responses are handled via standard HTTP POST routes, while server-to-client updates stream via HTTP `text/event-stream`.

--- a/.github/skills/kemal-sse/SKILL.md
+++ b/.github/skills/kemal-sse/SKILL.md
@@ -1,21 +1,17 @@
 ---
 name: kemal-sse
 description: Real-time Server-Sent Events (SSE) streaming in Kemal 1.12+, following established project patterns.
+license: MIT
 ---
 
 # Kemal Server-Sent Events (SSE)
 
 This skill provides expert guidance on implementing real-time unidirectional event streaming using Kemal's built-in `sse` helper (available in Kemal 1.12.0+).
 
-## Compatibility Matrix
+## Version Notes
 
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `sse` Route Helper & `Kemal::EventStream` | Supported (1.12.0+) | Supported |
-| Named Events (`event:`, `id:`, `retry:`) | Supported | Supported |
-| Automatic `text/event-stream` Headers | Supported | Supported |
-| Newline Injection Protection & CRLF Normalization | **Not available** | Supported (prevents SSE header/event injection) |
-| `retry` Field Int32 Overflow Fix | **Not available** | Supported |
+- `sse` route helper and `Kemal::EventStream` (named events, `id:`, `retry:`): since Kemal 1.12.0.
+- SSE injection protection (CR/LF rejected in `event`/`id`, CRLF normalization in `data` and comments) and the `retry` field Int32 overflow fix: Kemal master only.
 
 ## Core Mandates
 

--- a/.github/skills/kemal-upload/SKILL.md
+++ b/.github/skills/kemal-upload/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: kemal-upload
+description: Handling file uploads and storage in Kemal using body size safety configuration and established project patterns.
+---
+
+# Kemal File Uploads & Storage
+
+This skill provides expert guidance on implementing file uploads and storage in Kemal, with explicit safety bounds and validation, strictly following patterns from `src/kemal-by-example/file-upload-storage/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| Multipart Uploads (`env.params.files`) | Supported | Supported |
+| Global Request Body Limit (`Kemal.config.max_request_body_size`) | Supported (1.9+) | Supported |
+| Multipart Field Size Limit (`Kemal.config.max_multipart_form_field_size`) | Supported (1.11+) | Supported |
+| Relative Path Safety & Storage Sandboxing | Supported | Supported |
+
+## Core Mandates
+
+- **Global Size Limit Configuration (Security in Kemal 1.9+ & 1.11+):** Set global request and multipart limits in the entrypoint file:
+
+  ```crystal
+  # Maximum overall request body size (Kemal 1.9+, e.g. 50MB)
+  Kemal.config.max_request_body_size = 50 * 1024 * 1024
+
+  # Maximum individual multipart form field size (Kemal 1.11+, e.g. 8MB)
+  Kemal.config.max_multipart_form_field_size = 8 * 1024 * 1024
+  ```
+
+- **Uploading:** Use `env.params.files.has_key?("file")` to check for file presence, then `env.params.files["file"]` to access it:
+
+  ```crystal
+  unless env.params.files.has_key?("file")
+    env.redirect "/files?error=Please+choose+a+file+to+upload."
+    next ""
+  end
+  uploaded_file = env.params.files["file"]
+  ```
+
+- **Pre-Validation:** Check the size of the uploaded tempfile before storage:
+
+  ```crystal
+  max_size = 50_i64 * 1024 * 1024
+  uploaded_file.tempfile.rewind
+  tempfile_size = uploaded_file.tempfile.size
+
+  if tempfile_size > max_size
+    env.redirect "/files?error=File+size+must+be+50MB+or+smaller."
+    next ""
+  end
+  ```
+
+- **Extension Validation:** Check allowed extensions before processing:
+
+  ```crystal
+  unless StoredFile.allowed_extension?(original_name)
+    env.redirect "/files?error=Only+images,+PDF,+and+TXT+files+are+allowed."
+    next ""
+  end
+  ```
+
+- **Handling Files:**
+
+  ```crystal
+  extension = ::File.extname(original_name).downcase
+  stored_name = "#{Random::Secure.hex(16)}#{extension}"
+  destination = ::File.join(Kemal.config.public_folder, "uploads", stored_name)
+
+  ::File.open(destination, "w") do |file|
+    IO.copy(uploaded_file.tempfile, file)
+  end
+  ```
+
+- **MIME Type Detection:** Use a fallback for missing Content-Type headers:
+
+  ```crystal
+  mime_type = uploaded_file.headers["Content-Type"]? || "application/octet-stream"
+  ```
+
+- **File Deletion:** Always check existence before deleting:
+
+  ```crystal
+  ::File.delete(stored_file.storage_path) if ::File.exists?(stored_file.storage_path)
+  ```
+
+## Patterns from Source Code
+
+### Upload Route (file-upload-storage/src/routes/files.cr)
+
+```crystal
+post "/files/upload" do |env|
+  unless env.params.files.has_key?("file")
+    env.redirect "/files?error=Please+choose+a+file+to+upload."
+    next ""
+  end
+
+  uploaded_file = env.params.files["file"]
+  original_name = uploaded_file.filename || "upload"
+
+  unless StoredFile.allowed_extension?(original_name)
+    env.redirect "/files?error=Only+images,+PDF,+and+TXT+files+are+allowed."
+    next ""
+  end
+
+  max_size = 50_i64 * 1024 * 1024
+
+  # Check size before copying:
+  uploaded_file.tempfile.rewind
+  tempfile_size = uploaded_file.tempfile.size
+
+  if tempfile_size > max_size
+    env.redirect "/files?error=File+size+must+be+50MB+or+smaller."
+    next ""
+  end
+
+  extension = ::File.extname(original_name).downcase
+  stored_name = "#{Random::Secure.hex(16)}#{extension}"
+  destination = ::File.join(Kemal.config.public_folder, "uploads", stored_name)
+
+  ::File.open(destination, "w") do |file|
+    IO.copy(uploaded_file.tempfile, file)
+  end
+
+  mime_type = uploaded_file.headers["Content-Type"]? || "application/octet-stream"
+  StoredFile.create(original_name, stored_name, mime_type, tempfile_size)
+
+  env.redirect "/files?notice=File+uploaded+successfully."
+end
+```
+
+### StoredFile Model with Extension Validation (file-upload-storage/src/models/stored_file.cr)
+
+```crystal
+class StoredFile
+  include DB::Serializable
+
+  ALLOWED_EXTENSIONS = %w[.jpg .jpeg .png .gif .pdf .txt]
+
+  getter id : Int64?
+  getter original_name : String
+  getter stored_name : String
+  getter mime_type : String
+  getter size_bytes : Int64
+  getter created_at : String
+
+  def storage_path : String
+    ::File.join(Kemal.config.public_folder, "uploads", stored_name)
+  end
+
+  def self.allowed_extension?(filename : String) : Bool
+    ext = ::File.extname(filename).downcase
+    ALLOWED_EXTENSIONS.includes?(ext)
+  end
+end
+```
+
+### File Deletion Route
+
+```crystal
+post "/files/:id/delete" do |env|
+  id = env.params.url["id"]?.try(&.to_i64?)
+  stored_file = id ? StoredFile.find(id) : nil
+
+  if stored_file
+    ::File.delete(stored_file.storage_path) if ::File.exists?(stored_file.storage_path)
+    stored_file.delete
+    env.redirect "/files?notice=File+deleted+successfully."
+  else
+    env.response.status = :not_found
+    "File not found"
+  end
+end
+```
+
+## Best Practices
+
+- **Configuration:** Always configure `Kemal.config.max_request_body_size` and `Kemal.config.max_multipart_form_field_size` globally to mitigate resource exhaustion / DoS attacks.
+- **Extension Validation:** Use a helper like `StoredFile.allowed_extension?(name)` to validate extensions (e.g., `.jpg`, `.png`, `.pdf`, `.txt`).
+- **Unique Storage Names:** Always generate unique filenames using `Random::Secure.hex(16)` to prevent collisions.
+- **Cleanup:** Always use `::File.delete(path) if ::File.exists?(path)` when deleting files.
+- **Early Validation:** Check file presence and extension before processing to fail fast.
+
+## When to Use
+
+- When implementing file upload features.
+- When configuring Kemal to handle larger request bodies safely.
+- When managing stored files (e.g., deleting after use).

--- a/.github/skills/kemal-upload/SKILL.md
+++ b/.github/skills/kemal-upload/SKILL.md
@@ -1,20 +1,17 @@
 ---
 name: kemal-upload
 description: Handling file uploads and storage in Kemal using body size safety configuration and established project patterns.
+license: MIT
 ---
 
 # Kemal File Uploads & Storage
 
-This skill provides expert guidance on implementing file uploads and storage in Kemal, with explicit safety bounds and validation, strictly following patterns from `src/kemal-by-example/file-upload-storage/`.
+This skill provides expert guidance on implementing file uploads and storage in Kemal, with explicit safety bounds and validation, strictly following patterns from [`kemal-by-example/file-upload-storage`](https://github.com/sdogruyol/kemal-by-example/tree/master/file-upload-storage).
 
-## Compatibility Matrix
+## Version Notes
 
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| Multipart Uploads (`env.params.files`) | Supported | Supported |
-| Global Request Body Limit (`Kemal.config.max_request_body_size`) | Supported (1.9+) | Supported |
-| Multipart Field Size Limit (`Kemal.config.max_multipart_form_field_size`) | Supported (1.11+) | Supported |
-| Relative Path Safety & Storage Sandboxing | Supported | Supported |
+- `Kemal.config.max_request_body_size`: since Kemal 1.9.
+- `Kemal.config.max_multipart_form_field_size`: since Kemal 1.11.
 
 ## Core Mandates
 

--- a/.github/skills/kemal-view/SKILL.md
+++ b/.github/skills/kemal-view/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: kemal-view
+description: Rendering ECR templates and layouts with Kemal.
+---
+
+# Kemal View Rendering
+
+This skill provides expert guidance on rendering HTML templates using ECR (Embedded Crystal) in Kemal, strictly following patterns from `src/kemal-by-example/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `render` Macro (View only) | Supported | Supported |
+| `render` Macro with Layout (`view, layout`) | Supported | Supported |
+| Layout Yield (`<%= content %>`) | Supported | Supported |
+| Local Variable Bindings in ECR Scope | Supported | Supported |
+
+## Core Mandates
+
+- **Rendering:** Use `render "path/to/view.ecr"` for simple rendering.
+- **Layouts:** Use `render "path/to/view.ecr", "path/to/layout.ecr"` for layout support.
+- **Paths:** Always use relative paths from the project root (e.g., `src/views/index.ecr`).
+- **Data Passing:** Local variables in the route block are directly accessible within ECR templates.
+
+## Patterns from Source Code
+
+### Basic Route with View Rendering
+
+```crystal
+# blog/src/routes/posts.cr
+get "/posts" do
+  posts = Post.all
+  render "src/views/posts/index.ecr", "src/views/layouts/application.ecr"
+end
+```
+
+### Route with Local Variables for Views
+
+```crystal
+# ecommerce/src/routes/auth.cr
+get "/signup" do |env|
+  current_user = Ecommerce::Auth.current_user(env)
+  cart_count = if (user = current_user) && (uid = user.id)
+                 CartItem.total_quantity_for_user(uid)
+               else
+                 0_i64
+               end
+  error_message = nil
+
+  render "src/views/auth/signup.ecr", "src/views/layouts/application.ecr"
+end
+```
+
+### Edit Route with Conditional Rendering
+
+```crystal
+# blog/src/routes/posts.cr
+get "/posts/:id/edit" do |env|
+  id = env.params.url["id"]?.try(&.to_i64?)
+  post = id ? Post.find(id) : nil
+
+  if post
+    render "src/views/posts/edit.ecr", "src/views/layouts/application.ecr"
+  else
+    env.response.status = :not_found
+    "Post not found"
+  end
+end
+```
+
+### Layout Template Structure
+
+Typical layout file at `src/views/layouts/application.ecr`:
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <title>My App</title>
+</head>
+<body>
+  <nav>
+    <!-- Navigation content -->
+  </nav>
+
+  <main>
+    <%= content %>
+  </main>
+
+  <footer>
+    <!-- Footer content -->
+  </footer>
+</body>
+</html>
+```
+
+### View Template Example
+
+Typical view file at `src/views/posts/index.ecr`:
+
+```html
+<h1>Posts</h1>
+
+<% posts.each do |post| %>
+  <article>
+    <h2><%= post.title %></h2>
+    <p><%= post.body %></p>
+    <a href="/posts/<%= post.id %>/edit">Edit</a>
+  </article>
+<% end %>
+
+<a href="/posts/new">New Post</a>
+```
+
+### Error Rendering with Local Variables
+
+```crystal
+# ecommerce/src/routes/auth.cr
+post "/login" do |env|
+  email = env.params.body["email"]?.try(&.strip) || ""
+  password = env.params.body["password"]?.try(&.strip) || ""
+  user = User.authenticate(email, password)
+
+  if user
+    Ecommerce::Auth.sign_in(env, user)
+    env.redirect "/products"
+  else
+    current_user = nil
+    cart_count = 0_i64
+    error_message = "Invalid email or password."
+    env.response.status = :unprocessable_entity
+    render "src/views/auth/login.ecr", "src/views/layouts/application.ecr"
+  end
+end
+```
+
+## Best Practices
+
+- **Layout Structure:** Use `<%= content %>` in layout files to render the view content.
+- **Partials:** Use `render "path/to/_partial.ecr"` for reusable UI components (not shown in examples but standard practice).
+- **ECR Directives:** Prefer `<%= ... %>` for output and `<% ... %>` for logic/control flow.
+- **Sanitization:** Be mindful of XSS when outputting user-provided data. Use `HTML.escape` where necessary.
+- **Local Variables:** Pass data to views by defining local variables in the route block before calling `render`.
+- **Error Handling:** Handle missing resources (404) by checking models before rendering, or set appropriate status codes.
+
+## When to Use
+
+- When creating or modifying HTML views in a Kemal application.
+- When setting up or changing the main application layout.
+- When organizing view files and partials.

--- a/.github/skills/kemal-view/SKILL.md
+++ b/.github/skills/kemal-view/SKILL.md
@@ -1,20 +1,12 @@
 ---
 name: kemal-view
 description: Rendering ECR templates and layouts with Kemal.
+license: MIT
 ---
 
 # Kemal View Rendering
 
-This skill provides expert guidance on rendering HTML templates using ECR (Embedded Crystal) in Kemal, strictly following patterns from `src/kemal-by-example/`.
-
-## Compatibility Matrix
-
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `render` Macro (View only) | Supported | Supported |
-| `render` Macro with Layout (`view, layout`) | Supported | Supported |
-| Layout Yield (`<%= content %>`) | Supported | Supported |
-| Local Variable Bindings in ECR Scope | Supported | Supported |
+This skill provides expert guidance on rendering HTML templates using ECR (Embedded Crystal) in Kemal, strictly following patterns from [`kemal-by-example`](https://github.com/sdogruyol/kemal-by-example).
 
 ## Core Mandates
 
@@ -22,6 +14,7 @@ This skill provides expert guidance on rendering HTML templates using ECR (Embed
 - **Layouts:** Use `render "path/to/view.ecr", "path/to/layout.ecr"` for layout support.
 - **Paths:** Always use relative paths from the project root (e.g., `src/views/index.ecr`).
 - **Data Passing:** Local variables in the route block are directly accessible within ECR templates.
+- **Escaping:** ECR does not auto-escape. Wrap user-provided values in `HTML.escape(...)` (`require "html"`) when outputting with `<%= ... %>`.
 
 ## Patterns from Source Code
 
@@ -97,15 +90,15 @@ Typical layout file at `src/views/layouts/application.ecr`:
 
 ### View Template Example
 
-Typical view file at `src/views/posts/index.ecr`:
+Typical view file at `src/views/posts/index.ecr`. ECR does **not** auto-escape output, so any user-provided value rendered with `<%= ... %>` must go through `HTML.escape` (stdlib, `require "html"`) to prevent XSS:
 
 ```html
 <h1>Posts</h1>
 
 <% posts.each do |post| %>
   <article>
-    <h2><%= post.title %></h2>
-    <p><%= post.body %></p>
+    <h2><%= HTML.escape(post.title) %></h2>
+    <p><%= HTML.escape(post.body) %></p>
     <a href="/posts/<%= post.id %>/edit">Edit</a>
   </article>
 <% end %>
@@ -140,7 +133,7 @@ end
 - **Layout Structure:** Use `<%= content %>` in layout files to render the view content.
 - **Partials:** Use `render "path/to/_partial.ecr"` for reusable UI components (not shown in examples but standard practice).
 - **ECR Directives:** Prefer `<%= ... %>` for output and `<% ... %>` for logic/control flow.
-- **Sanitization:** Be mindful of XSS when outputting user-provided data. Use `HTML.escape` where necessary.
+- **Escaping (XSS):** ECR performs no automatic HTML escaping. Always wrap user-provided data in `HTML.escape(...)` inside `<%= ... %>`; only render raw HTML you generated yourself (like the layout's `<%= content %>`).
 - **Local Variables:** Pass data to views by defining local variables in the route block before calling `render`.
 - **Error Handling:** Handle missing resources (404) by checking models before rendering, or set appropriate status codes.
 

--- a/.github/skills/kemal-websocket/SKILL.md
+++ b/.github/skills/kemal-websocket/SKILL.md
@@ -1,22 +1,18 @@
 ---
 name: kemal-websocket
 description: Implementing real-time bi-directional communication with WebSockets in Kemal, origin security, and lifecycle management.
+license: MIT
 ---
 
 # Kemal WebSocket Integration
 
-This skill provides expert guidance on using WebSockets for real-time features in Kemal, with precise security guidance for Kemal 1.12.0 release versus Kemal master, strictly following patterns from `src/kemal-by-example/real-time-dashboard/` and `src/kemal-by-example/twitter-clone/`.
+This skill provides expert guidance on using WebSockets for real-time features in Kemal, with version-aware origin security guidance, strictly following patterns from [`kemal-by-example/real-time-dashboard`](https://github.com/sdogruyol/kemal-by-example/tree/master/real-time-dashboard) and [`kemal-by-example/twitter-clone`](https://github.com/sdogruyol/kemal-by-example/tree/master/twitter-clone).
 
-## Compatibility Matrix
+## Version Notes
 
-| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
-| :--- | :--- | :--- |
-| `ws` Route Helper & Lifecycle | Supported | Supported |
-| Origin Validation Config (`websocket_allowed_origins`) | Supported | Supported |
-| **Default Origin Policy** (`allowed_origins = []`) | **Allow-All (Open by default)** | **Same-Origin (Strict by default)** |
-| Allow-All Escape Hatch (`["*"]`) | N/A (default is already open) | Supported (opt-in allow-all) |
-| Non-GET Upgrade Rejection (RFC 6455 §4.1) | **Not available** (returns standard error) | Supported (`405 Method Not Allowed` + `Allow: GET`) |
-| Connection Teardown on Handshake Failure | Standard close | Explicit `Connection: close` (anti-smuggling) |
+- **Default Origin policy changed on master:** with an empty `websocket_allowed_origins` (the default), Kemal master enforces same-origin and rejects missing or mismatched `Origin` headers with `403 Forbidden`; releases up to 1.12.0 allow **all** origins (CSWSH risk — configure an allowlist explicitly, see below).
+- `websocket_allowed_origins = ["*"]` opt-in allow-all: Kemal master only.
+- Non-GET upgrade rejection (RFC 6455 §4.1, `405 Method Not Allowed` + `Allow: GET`) and explicit `Connection: close` after a rejected handshake: Kemal master only.
 
 ## Core Mandates
 
@@ -29,22 +25,22 @@ This skill provides expert guidance on using WebSockets for real-time features i
   ```
 
 - **Origin Validation & CSWSH Security:**
-  - **CRITICAL ON KEMAL 1.12.0 RELEASE:** An empty `Kemal.config.websocket_allowed_origins = [] of String` (default) **permits all origins** (`return true if allowed.empty?`).
-    To protect against Cross-Site WebSocket Hijacking (CSWSH) in production on Kemal 1.12.0, you **MUST explicitly configure allowed origins**:
+  - **CRITICAL ON STABLE RELEASES (1.12.0 and earlier):** An empty `Kemal.config.websocket_allowed_origins = [] of String` (default) **permits all origins** (`return true if allowed.empty?`).
+    To protect against Cross-Site WebSocket Hijacking (CSWSH) in production on these releases, you **MUST explicitly configure allowed origins**:
 
     ```crystal
-    # MANDATORY on Kemal 1.12.0 to protect against CSWSH:
+    # MANDATORY on 1.12.0 and earlier to protect against CSWSH:
     Kemal.config.websocket_allowed_origins = %w[https://myapp.com http://localhost:3000]
     ```
 
-  - **ON KEMAL MASTER (Unreleased / Next):** An empty `websocket_allowed_origins` defaults to strict **same-origin** enforcement (matching request `Host`). Missing or mismatched `Origin` headers are rejected with `403 Forbidden`. To explicitly allow all origins on master:
+  - **ON KEMAL MASTER (not yet in a stable release):** An empty `websocket_allowed_origins` defaults to strict **same-origin** enforcement (matching request `Host`). Missing or mismatched `Origin` headers are rejected with `403 Forbidden`. To explicitly allow all origins on master:
 
     ```crystal
-    # Kemal master / upcoming 1.13.0 opt-in allow-all:
+    # Kemal master only — opt-in allow-all:
     Kemal.config.websocket_allowed_origins = ["*"]
     ```
 
-- **Protocol Compliance (RFC 6455 §4.1) — *[Kemal Master / Unreleased]*:**
+- **Protocol Compliance (RFC 6455 §4.1) — *[Kemal master only]*:**
   - On Kemal master, WebSocket upgrade handshakes require the `GET` method. Non-GET upgrade requests (`POST`, `QUERY`, etc.) are automatically rejected with `405 Method Not Allowed`, `Allow: GET`, and `Connection: close`.
   - Failed handshakes close the connection immediately to prevent WebSocket connection smuggling.
 
@@ -81,8 +77,10 @@ require "kemal"
 
 module RealTimeDashboard
   class DashboardHub
-    include JSON::Serializable
-
+    # NOTE: Do not `include JSON::Serializable` here — it removes the default
+    # constructor, and sockets/mutexes are not serializable anyway. Serialize a
+    # plain stats payload (e.g. `{"total_requests" => total_requests}.to_json`)
+    # when broadcasting instead.
     getter total_requests : Int64 = 0_i64
     getter active_users : Int32 = 0
 
@@ -118,7 +116,7 @@ end
 ```crystal
 require "kemal"
 
-# Configure allowed origins explicitly (mandatory on 1.12.0 for security, recommended everywhere)
+# Configure allowed origins explicitly (mandatory on 1.12.0 and earlier for security, recommended everywhere)
 Kemal.config.websocket_allowed_origins = %w[http://127.0.0.1:3000 http://localhost:3000]
 
 HUB = RealTimeDashboard::DashboardHub.new

--- a/.github/skills/kemal-websocket/SKILL.md
+++ b/.github/skills/kemal-websocket/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: kemal-websocket
+description: Implementing real-time bi-directional communication with WebSockets in Kemal, origin security, and lifecycle management.
+---
+
+# Kemal WebSocket Integration
+
+This skill provides expert guidance on using WebSockets for real-time features in Kemal, with precise security guidance for Kemal 1.12.0 release versus Kemal master, strictly following patterns from `src/kemal-by-example/real-time-dashboard/` and `src/kemal-by-example/twitter-clone/`.
+
+## Compatibility Matrix
+
+| Feature | Kemal 1.12.0 (Release) | Kemal Master (Unreleased / Next) |
+| :--- | :--- | :--- |
+| `ws` Route Helper & Lifecycle | Supported | Supported |
+| Origin Validation Config (`websocket_allowed_origins`) | Supported | Supported |
+| **Default Origin Policy** (`allowed_origins = []`) | **Allow-All (Open by default)** | **Same-Origin (Strict by default)** |
+| Allow-All Escape Hatch (`["*"]`) | N/A (default is already open) | Supported (opt-in allow-all) |
+| Non-GET Upgrade Rejection (RFC 6455 §4.1) | **Not available** (returns standard error) | Supported (`405 Method Not Allowed` + `Allow: GET`) |
+| Connection Teardown on Handshake Failure | Standard close | Explicit `Connection: close` (anti-smuggling) |
+
+## Core Mandates
+
+- **WebSocket Route Definition:** Use the `ws` helper to define WebSocket endpoints:
+
+  ```crystal
+  ws "/socket" do |socket, env|
+    # Socket lifecycle callbacks
+  end
+  ```
+
+- **Origin Validation & CSWSH Security:**
+  - **CRITICAL ON KEMAL 1.12.0 RELEASE:** An empty `Kemal.config.websocket_allowed_origins = [] of String` (default) **permits all origins** (`return true if allowed.empty?`).
+    To protect against Cross-Site WebSocket Hijacking (CSWSH) in production on Kemal 1.12.0, you **MUST explicitly configure allowed origins**:
+
+    ```crystal
+    # MANDATORY on Kemal 1.12.0 to protect against CSWSH:
+    Kemal.config.websocket_allowed_origins = %w[https://myapp.com http://localhost:3000]
+    ```
+
+  - **ON KEMAL MASTER (Unreleased / Next):** An empty `websocket_allowed_origins` defaults to strict **same-origin** enforcement (matching request `Host`). Missing or mismatched `Origin` headers are rejected with `403 Forbidden`. To explicitly allow all origins on master:
+
+    ```crystal
+    # Kemal master / upcoming 1.13.0 opt-in allow-all:
+    Kemal.config.websocket_allowed_origins = ["*"]
+    ```
+
+- **Protocol Compliance (RFC 6455 §4.1) — *[Kemal Master / Unreleased]*:**
+  - On Kemal master, WebSocket upgrade handshakes require the `GET` method. Non-GET upgrade requests (`POST`, `QUERY`, etc.) are automatically rejected with `405 Method Not Allowed`, `Allow: GET`, and `Connection: close`.
+  - Failed handshakes close the connection immediately to prevent WebSocket connection smuggling.
+
+- **Socket Lifecycle Callbacks:**
+  - `socket.on_message`: Handle incoming text messages from client
+  - `socket.on_close`: Handle socket disconnection and perform cleanup
+  - `socket.on_ping` / `socket.on_pong`: Handle heartbeat signals
+
+- **Concurrency Safety:** Always protect shared socket collections with a `Mutex`:
+
+  ```crystal
+  class Hub
+    @sockets = Array(HTTP::WebSocket).new
+    @mutex = Mutex.new
+
+    def register(socket)
+      @mutex.synchronize { @sockets << socket }
+    end
+
+    def unregister(socket)
+      @mutex.synchronize { @sockets.delete(socket) }
+    end
+  end
+  ```
+
+- **Error Handling:** Rescue `IO::Error | Socket::Error` when sending to sockets and unregister closed sockets.
+
+## Patterns from Source Code
+
+### Centralized WebSocket Hub (real-time-dashboard/src/services/dashboard_hub.cr)
+
+```crystal
+require "kemal"
+
+module RealTimeDashboard
+  class DashboardHub
+    include JSON::Serializable
+
+    getter total_requests : Int64 = 0_i64
+    getter active_users : Int32 = 0
+
+    @sockets = Array(HTTP::WebSocket).new
+    @mutex = Mutex.new
+
+    def register(socket : HTTP::WebSocket)
+      @mutex.synchronize { @sockets << socket }
+    end
+
+    def unregister(socket : HTTP::WebSocket)
+      @mutex.synchronize { @sockets.delete(socket) }
+    end
+
+    def broadcast(message : String)
+      @mutex.synchronize do
+        @sockets.reject! do |socket|
+          begin
+            socket.send(message)
+            false
+          rescue IO::Error | Socket::Error
+            true # Remove failed socket
+          end
+        end
+      end
+    end
+  end
+end
+```
+
+### WebSocket Route Setup with Origin Security
+
+```crystal
+require "kemal"
+
+# Configure allowed origins explicitly (mandatory on 1.12.0 for security, recommended everywhere)
+Kemal.config.websocket_allowed_origins = %w[http://127.0.0.1:3000 http://localhost:3000]
+
+HUB = RealTimeDashboard::DashboardHub.new
+
+ws "/dashboard/socket" do |socket, env|
+  HUB.register(socket)
+
+  socket.on_message do |msg|
+    # Handle incoming client messages (spawn long-running work to avoid blocking fiber)
+    spawn do
+      # process msg
+    end
+  end
+
+  socket.on_close do
+    HUB.unregister(socket)
+  end
+end
+```
+
+## Best Practices
+
+- **Security First:** Always configure `Kemal.config.websocket_allowed_origins` explicitly in production. Origin validation is a browser boundary, not authentication/authorization.
+- **Mutex Synchronization:** Wrap all modifications and iterations over socket lists in `@mutex.synchronize`.
+- **Selective Rejection:** Use `@sockets.reject!` inside broadcast loops to cleanly strip dead sockets without deadlocks.
+- **Graceful Teardown:** Unregister sockets in `on_close` callbacks.
+
+## When to Use
+
+- When building real-time bi-directional chat applications, collaborative tools, or active telemetry dashboards.
+- When client and server communicate via continuous socket connections.


### PR DESCRIPTION
### Description
This PR integrates a comprehensive, production-grade suite of AI agent skills (`.github/skills/`) for Kemal, modernizing the existing `crystal-kemal` skill and adding 11 specialized domain skills derived from real-world implementations in [kemal-by-example](https://github.com/sdogruyol/kemal-by-example).

Maintained and formally audited under [kemal-skills](https://gitlab.com/renich/kemal-skills) following the methodology in [METHOD.rst](https://gitlab.com/renich/kemal-skills/-/blob/master/METHOD.rst).

### Summary of Changes
1. **Modernize `crystal-kemal`**:
   - Replace deprecated `add_handler` with modern `use` keyword (Kemal 1.10+).
   - Use safe parameter access (`env.params.url["id"]?`, `env.params.json["key"]?.as?(String)`).
   - Use `%w[...]` string array literals and symbol HTTP status codes (`:created`, `:forbidden`).
   - Clarify 1.12.0 release (allow-all default) vs `master` (same-origin default) WebSocket origin security.
   - Cross-reference the modular domain skills.
2. **Add 11 Specialized Domain Skills in `.github/skills/`**:
   - `kemal-core`: Routing verbs, modular `Kemal::Router`, version gates (`QUERY`, `max_ranges`).
   - `kemal-websocket`: Real-time bi-directional sockets, CSWSH origin allowlisting, connection teardown.
   - `kemal-sse`: Server-Sent Events streaming, newline injection protection, reconnect timeouts.
   - `kemal-json`: Canonical JSON response helpers (`env.json`, `env.status`), safe JSON decoding.
   - `kemal-middleware`: Handler classes, `only`/`exclude` macro scoping, HMAC handlers.
   - `kemal-upload`: Secure multipart upload processing, size bounding, path traversal protection.
   - `kemal-auth`: Session management with `kemal-session`, Bcrypt hashing, safe session unwrapping.
   - `kemal-database`: SQLite database initialization, `DB::Serializable`, thread-safe Mutex singletons.
   - `kemal-oauth`: OAuth2 authorization flows, cryptographically secure CSRF state verification.
   - `kemal-orm`: Crecto ORM models, declarative validations, schema migrations.
   - `kemal-view`: ECR templates, application layouts, safe view evaluation.

### Verification
- Ran `crystal spec` (all 348 examples passing, 0 failures).
- Validated YAML frontmatter schema (`name:`, `description:`) across all skills.