### PR TITLE
docs(skills): harden domain skills and update 1.13.0 operations guidance

### DIFF
--- a/.github/skills/crystal-kemal/references/operations.md
+++ b/.github/skills/crystal-kemal/references/operations.md
@@ -7,13 +7,14 @@ Set application-specific limits rather than copying example values blindly:
 ```crystal
 Kemal.config.max_request_body_size = 10 * 1024 * 1024
 Kemal.config.max_multipart_form_field_size = 8 * 1024 * 1024
+Kemal.config.max_ranges = 16 # Part limit per Range request (since 1.13.0; set to 0 to ignore Range headers)
 ```
 
 Multipart limits apply to individual multipart fields/file parts according to current Kemal behavior.
 
 ## Security baseline
 
-Typical controls include explicit WebSocket origins, hidden framework headers when desired, request/upload limits, HTTPS, deliberate security headers, authorization on sensitive routes, server-controlled file paths, and protection of secrets.
+Typical controls include explicit WebSocket origins, disabled `X-Powered-By` header by default (`Kemal.config.powered_by_header = false` since 1.13.0), request/multipart/Range size limits, HTTPS, deliberate security headers, authorization on sensitive routes, server-controlled file paths, and protection of secrets.
 
 Third-party security middleware may be appropriate, but verify maintenance status and compatibility before adding dependencies.
 

--- a/.github/skills/kemal-core/SKILL.md
+++ b/.github/skills/kemal-core/SKILL.md
@@ -14,6 +14,7 @@ Everything in this skill works on current Kemal unless marked otherwise.
 
 - HTTP `QUERY` method (RFC 10008) — `query`, `before_query`, `after_query`: since Kemal 1.13.0 (on 1.12.0 and earlier, use `post` or `get` with query parameters).
 - `Kemal.config.max_ranges` (Range request bounds): since Kemal 1.13.0.
+- Disabled `X-Powered-By` header by default (`Kemal.config.powered_by_header = false`): since Kemal 1.13.0.
 - Response helpers (`env.json`, `env.status`, `env.html`, `env.text`): since Kemal 1.10.
 - `Kemal::Router`, `mount`, `namespace`: since Kemal 1.10.
 - `Kemal.config.max_request_body_size`: since Kemal 1.9. `Kemal.config.shutdown_timeout`: since Kemal 1.10.1.
@@ -146,6 +147,10 @@ mount "/admin", admin_router
   ```crystal
   # Kemal 1.13.0+:
   Kemal.config.max_ranges = 16 # set to 0 to ignore Range headers entirely
+  ```
+- **Powered-By Header (Kemal 1.13.0+):** Kemal disables the `X-Powered-By: Kemal` response header by default. To re-enable it if required:
+  ```crystal
+  Kemal.config.powered_by_header = true
   ```
 - **Graceful Shutdown (Kemal 1.10.1+):** Configure shutdown timeout so in-flight requests finish cleanly before exit:
   ```crystal

--- a/.github/skills/kemal-database/SKILL.md
+++ b/.github/skills/kemal-database/SKILL.md
@@ -60,9 +60,9 @@ This skill provides expert guidance on integrating SQLite databases with Kemal u
   end
   ```
 
-- **Data Retrieval:** Use `query_all` and `query_one?` with the `as: Class` argument:
-  - `Database.connection.query_all("SELECT * FROM items", as: Item)`
-  - `Database.connection.query_one?("SELECT * FROM items WHERE id = ?", id, as: Item)`
+- **Data Retrieval:** Use `query_all` and `query_one?` with explicit column lists and the `as: Class` argument:
+  - `Database.connection.query_all("SELECT id, name, created_at FROM items", as: Item)`
+  - `Database.connection.query_one?("SELECT id, name, created_at FROM items WHERE id = ?", id, as: Item)`
 
 ## Patterns from Source Code
 

--- a/.github/skills/kemal-middleware/SKILL.md
+++ b/.github/skills/kemal-middleware/SKILL.md
@@ -13,6 +13,8 @@ This skill provides expert guidance on creating and using custom middleware in K
 - `use` registration (global and path-scoped): since Kemal 1.10.
 - `only` / `exclude` with a single method and exact paths: all supported versions.
 - `only` / `exclude` with `"*"` methods and `"/*"` path globs: since Kemal 1.13.0 — do **not** use the glob syntax on 1.12.0 or earlier, where it matches every path (see the warning below).
+- `HEAD` fallback route-scoped dispatch: since Kemal 1.13.0. On Kemal 1.12.0 and earlier, `HEAD` requests falling back to `GET` routes bypassed `GET`-scoped filters (`before_get`) and `GET`-scoped `only` / `exclude` middleware because dispatch checked the literal request method (`HEAD`) rather than the serving route method, creating an authentication bypass risk ([GHSA-jf9q-62h3-924j](https://github.com/kemalcr/kemal/security/advisories/GHSA-jf9q-62h3-924j)). Kemal 1.13.0+ evaluates both the request method and the serving route's effective method.
+- `Kemal::Router` filters registered with trailing `/*` match path subtrees: since Kemal 1.13.0 (on 1.12.0 and earlier, trailing `*` was treated as a literal path segment and silently failed to register/match routes).
 
 ## Core Mandates
 


### PR DESCRIPTION
### Summary of Changes

This PR polishes and hardens the agent skill definitions in `.github/skills/` following the 1.13.0 release:

1. **`kemal-core`**: Document that `X-Powered-By` is disabled by default since 1.13.0 (`Kemal.config.powered_by_header = false`) and how to re-enable it if needed.
2. **`operations.md`**: Add `Kemal.config.max_ranges = 16` to resource limits and include `powered_by_header` in the security baseline checklist.
3. **`kemal-database`**: Standardize Core Mandates data retrieval examples to use explicit column lists (`SELECT id, name, created_at FROM items`), aligning with the explicit column list best practice rule.
4. **`kemal-middleware`**: Document route-scoped filter and middleware dispatch for `HEAD` requests falling back to `GET` routes (GHSA-jf9q-62h3-924j) and trailing wildcard (`/*`) filter matching in `Kemal::Router`.

### Verification

- Ran `crystal spec` (353 examples, 0 failures, 0 errors).
- All skill definitions remain strictly self-contained with no external repository dependencies.