### PR TITLE
Reduce per-request allocations in filter dispatch and Date header generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+- Skip filter tree lookups when no path-scoped filters are registered. Apps using only global filters (`before_all` and friends) no longer pay 4-6 radix lookups and key allocations per request [#781](https://github.com/kemalcr/kemal/pull/781).
+
+- Cache the `Date` response header string per second instead of formatting it on every request. The value is unchanged: the string is reused only within the same UTC second [#781](https://github.com/kemalcr/kemal/pull/781).
+
 # 1.13.0 (24-08-2026)
 
 - ***(SECURITY)*** Delete uploaded temporary files for every request, not only for requests that reach `Kemal::RouteHandler` [#776](https://github.com/kemalcr/kemal/issues/776). `Kemal::ParamParser` spools multipart file parts to `File.tempfile` as soon as anything touches `params` — including `params.body` on a multipart request, which writes every file part out just to read one form field — but cleanup ran in the route handler's `ensure`. Anything that answered before the route handler leaked those files permanently: a `before` filter that `halt`s into a custom `error` handler (Kemal's documented auth pattern), an exception raised in a filter, and middleware that responds without calling the next handler. An unauthenticated client could therefore fill the disk one *rejected* upload at a time — with default settings, 20 curl requests left 153 MB behind for good. Cleanup now lives in `Kemal::InitHandler`, which heads the handler chain, so it runs however the request ends. A handler registered ahead of it with `use handler, 0` still owns the cleanup for uploads it parses itself, as that position already opts out of everything else `Kemal::InitHandler` does. Thanks @canermastan for the report :pray:

--- a/src/kemal/filter_handler.cr
+++ b/src/kemal/filter_handler.cr
@@ -132,6 +132,11 @@ module Kemal
         global_filters.each &.call(context)
       end
 
+      # With only global filters registered (`before_all` and friends) the tree
+      # is empty, yet every request would still pay a radix key allocation and
+      # a lookup per verb/type combination - four to six times per request.
+      return if path_filters_empty?
+
       lookup = lookup_filters_for_path_type(verb, path, type)
       if lookup.found? && lookup.payload.is_a? Array(FilterBlock)
         blocks = lookup.payload
@@ -148,6 +153,14 @@ module Kemal
     # This returns a lookup for verb/path/type
     private def lookup_filters_for_path_type(verb : String?, path : String, type)
       @tree.find radix_path(verb, path, type)
+    end
+
+    # `tree` is a public getter, so filters can enter the radix tree without
+    # going through `_add_route_filter` - ask the tree itself rather than
+    # tracking a flag that such additions would bypass.
+    private def path_filters_empty? : Bool
+      root = @tree.root
+      root.children.empty? && root.payload?.nil?
     end
 
     private def radix_path(verb : String?, path : String, type : Symbol)

--- a/src/kemal/init_handler.cr
+++ b/src/kemal/init_handler.cr
@@ -8,10 +8,26 @@ module Kemal
 
     INSTANCE = new
 
+    # An HTTP `Date` value only changes once a second, while formatting one
+    # costs ~215ns and 240B of garbage per request. Held as a single immutable
+    # object behind an `Atomic` because the server may run in a parallel
+    # execution context: the atomic swap publishes the fully constructed
+    # object to other threads instead of tearing a timestamp/string pair
+    # updated separately.
+    private class CachedDate
+      getter unix : Int64
+      getter value : String
+
+      def initialize(@unix : Int64, @value : String)
+      end
+    end
+
+    @cached_date = Atomic(CachedDate).new(CachedDate.new(Int64::MIN, ""))
+
     def call(context : HTTP::Server::Context)
       context.response.headers.add "X-Powered-By", "Kemal" if Kemal.config.powered_by_header?
       context.response.content_type = "text/html" unless context.response.headers.has_key?("Content-Type")
-      context.response.headers.add "Date", HTTP.format_time(Time.utc)
+      context.response.headers.add "Date", date_header
       call_next context
     ensure
       # Uploads are spooled to disk by `Kemal::ParamParser` the moment anything
@@ -37,6 +53,17 @@ module Kemal
         # log line, not a broken response.
         Log.error(exception: ex) { "Failed to clean up uploaded temporary files" }
       end
+    end
+
+    private def date_header : String
+      now = Time.utc
+      epoch = now.to_unix
+      cached = @cached_date.get
+      return cached.value if cached.unix == epoch
+
+      formatted = HTTP.format_time(now)
+      @cached_date.set(CachedDate.new(epoch, formatted))
+      formatted
     end
   end
 end


### PR DESCRIPTION
### Description of the Change

Two hot-path optimizations. Measured with `Benchmark.ips` (`--release`, Crystal 1.21) and a load test. No behavior change.

**Skip radix lookups when the filter tree is empty**

With only global filters (`before_all` and friends) the radix tree is empty, but every request still allocated a lookup key and walked the tree 4–6 times (~244ns, 640B). `FilterHandler` now checks whether the tree has anything before looking up. Asking the tree itself means filters added through the public `tree` getter still work.

**Cache the Date header per second**

`HTTP.format_time(Time.utc)` ran on every request (~215ns, 240B). `Date` only changes once a second, so the formatted string is now rebuilt on second boundaries and reused (~14ns, no alloc). The cache is an immutable object swapped through an `Atomic`, since apps can serve requests from multiple threads (a `Fiber::ExecutionContext::Parallel` context on recent Crystal, or `-Dpreview_mt` on older versions).

### Alternate Designs

A separate “tree is empty” flag would drift if someone mutates `tree` directly. Interning just the radix key would still walk an empty tree.

For `Date`, a background fiber or a per-thread cache is more moving parts than an atomic swap of an immutable string. Formatting on every response still allocates.

### Benefits

- ~460ns and ~880B less garbage per request for a typical `before_all` app.
- Load test (hello world + `before_all`, cryload, 10 paired rounds, `-c 64`): median +2.8% req/s, slightly lower avg/p99 (noisy local machine, the microbenchmarks are the primary evidence).
- 353 specs pass. Filter order, bodies, and status codes are unchanged.

### Possible Drawbacks

The Date cache adds no staleness: the string is reused only within the same UTC second, so it matches per-request formatting byte for byte. The empty-tree check is an extra branch; it only matters when the tree is empty, which is the common case this targets.
