### PR TITLE
Count ws routes as GET when collecting allowed methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-- ***(BREAKING)*** Answer a request whose path is routed for another HTTP method with `405 Method Not Allowed` and the `Allow` header instead of `404`, per [RFC 9110 §15.5.6](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.6). With only `get "/posts"` registered, `POST /posts` and `OPTIONS /posts` returned `404` and reached the `error 404` handler; they now return `405` with `Allow: GET, HEAD` and reach `error 405`. Anything asserting `404` for a wrong-method request — tests, client retry logic, monitoring rules — has to be updated. A path that is not routed at all is still a `404`, and a path served only by a `ws` route is unchanged. `HEAD` appears in `Allow` wherever a `GET` route exists, matching the `HEAD` -> `GET` fallback. The `Allow` header is set before the error handler runs, so a custom `error 405` owns the body but cannot drop the header the RFC makes mandatory; without one, the body is the plain `Method Not Allowed`. Registering `error 405` also makes `before_all` filters run for *every* unmatched request, plain 404s included - the same over-approximation the existing `error 404` branch already had, now reachable through a second status code. Automatic `OPTIONS` responses are not part of this change.
+- ***(BREAKING)*** Answer a request whose path is routed for another HTTP method with `405 Method Not Allowed` and the `Allow` header instead of `404`, per [RFC 9110 §15.5.6](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.6). With only `get "/posts"` registered, `POST /posts` and `OPTIONS /posts` returned `404` and reached the `error 404` handler; they now return `405` with `Allow: GET, HEAD` and reach `error 405`. Anything asserting `404` for a wrong-method request — tests, client retry logic, monitoring rules — has to be updated. A path that is not routed at all is still a `404`; `ws` routes are covered by the entry below. `HEAD` appears in `Allow` wherever a `GET` route exists, matching the `HEAD` -> `GET` fallback. The `Allow` header is set before the error handler runs, so a custom `error 405` owns the body but cannot drop the header the RFC makes mandatory; without one, the body is the plain `Method Not Allowed`. Registering `error 405` also makes `before_all` filters run for *every* unmatched request, plain 404s included - the same over-approximation the existing `error 404` branch already had, now reachable through a second status code. Automatic `OPTIONS` responses are not part of this change.
 
 ```crystal
 get "/posts" do
@@ -16,6 +16,31 @@ error 405 do |env|
   {error: "Method not allowed", allow: env.response.headers["Allow"]}.to_json
 end
 ```
+
+- Count a `ws` route as `GET` when collecting the `Allow` header, since the WebSocket handshake is a `GET` request ([RFC 6455 §4.1](https://www.rfc-editor.org/rfc/rfc6455#section-4.1)). Two fixes:
+
+  - A path served only by `ws` now answers wrong-method requests with `405` and `Allow: GET`. Previously `Kemal::WebSocketHandler` passed a non-handshake request straight through and the route lookup missed, so `POST /chat` ended as a `404` — or, with no `error 404` handler registered, an empty `200`.
+  - A path carrying both `ws` and HTTP routes no longer reports an `Allow` that omits the handshake: with `ws "/chat"` and `post "/chat"`, `PUT /chat` answers `Allow: GET, POST` rather than `Allow: POST`.
+
+  - `Kemal::WebSocketHandler` no longer hardcodes `Allow: GET` when it rejects a non-GET upgrade attempt. `Allow` describes the methods the *resource* supports ([RFC 9110 §10.2.1](https://www.rfc-editor.org/rfc/rfc9110#section-10.2.1)), so with `ws "/chat"` and `post "/chat"` a `POST` carrying `Upgrade: websocket` now answers `Allow: GET, POST` instead of sending the client away from a verb the path really serves. A path with only a `ws` route still answers `Allow: GET`.
+
+  `HEAD` is not advertised for a `ws` route — the handshake is the only thing served there. And a request whose own method is already in the `Allow` list is not a `405`: a plain `GET` on a `ws` path is a handshake missing its `Upgrade` header, so it stays a `404` instead of being told `405, Allow: GET`. `426 Upgrade Required` ([RFC 9110 §15.5.22](https://www.rfc-editor.org/rfc/rfc9110#section-15.5.22)) was considered for that case and deliberately not adopted: a plain `GET` there is a client bug, and `404` versus `426` does not change what the client has to do.
+
+```crystal
+ws "/chat" do |socket, env|
+  socket.send("hi")
+end
+
+post "/chat" do
+  "post"
+end
+
+# PUT  /chat -> 405, Allow: GET, POST
+# GET  /chat -> 404 (no `Upgrade` header, so not a handshake)
+```
+
+
+
 
 - Report a static file that exists but cannot be opened as `404`, as the standard library's `HTTP::StaticFileHandler` does. Kemal's override served files through `send_file` without the stdlib's `File::Error` rescue, so a file under `public/` without read permission answered `500` — with the absolute path on the development error page, and the file's `ETag` and `Last-Modified` on the response, confirming to the client that the file was there. The response is now the plain `404` the stdlib sends, with no header derived from the file.
 - ***(SECURITY)*** Cap the number of file parts in a `multipart/form-data` request [#793](https://github.com/kemalcr/kemal/issues/793). `max_request_body_size` bounds the bytes but said nothing about the parts, and every file part is spooled to its own temporary file whose handle stays open until the request is over: an 8 MB body of one-byte parts held some 100,000 open file descriptors and temporary files for the length of one request, enough to take a process with the default `ulimit -n 1024` past `accept()` from a single unauthenticated request. `Kemal.config.max_file_uploads` (default `128`) now bounds the file parts; a request carrying more is answered with `413` and the body `Too many file parts (max N)` before the next part is written to disk, and the parts already spooled are cleaned up with the request. Form fields without a filename are not counted. `Kemal::Exceptions::PayloadTooLarge.new` now takes an optional message for this. Two related leaks are closed as well: a file part whose field name repeats an earlier one used to replace that upload in `params.files` without removing its temporary file, leaving it on disk for good; and `params.all_files` did not parse the body on its own, so it was always empty unless `params.files` had been read first.

--- a/README.md
+++ b/README.md
@@ -179,6 +179,21 @@ error 405 do |env|
 end
 ```
 
+A `ws` route counts as `GET`, because the WebSocket handshake is a `GET` request. It is listed without `HEAD`, and a plain `GET` on such a path — a handshake missing its `Upgrade` header — stays a `404` rather than being answered with a nonsensical `Allow: GET`.
+
+```crystal
+ws "/chat" do |socket, env|
+  socket.send("hi")
+end
+
+post "/chat" do
+  "post"
+end
+
+# PUT  /chat -> 405, Allow: GET, POST
+# GET  /chat -> 404 (no `Upgrade` header, so not a handshake)
+```
+
 NOTE: `Kemal::InitHandler` presets `Content-Type: text/html` on every response, so an error handler returning anything else has to set the content type itself.
 
 NOTE: Put authentication in `before_all` or in middleware rather than in a path-scoped filter like `before_get "/admin/*"`. Path-scoped filters do not run when no route matches, so a wrong-method request answers `405` with `Allow` — confirming the path exists — without ever reaching the guard.

--- a/spec/route_handler_spec.cr
+++ b/spec/route_handler_spec.cr
@@ -646,6 +646,13 @@ describe "Kemal::RouteHandler" do
       response.body.should eq("not found")
     end
 
+    # `GET` is what a WebSocket path serves, so a `GET` that missed cannot be a
+    # 405 - it is a handshake without the `Upgrade` header. Answering
+    # "405, Allow: GET" to a `GET` would be nonsense, so it stays a 404.
+    #
+    # `426 Upgrade Required` (RFC 9110 §15.5.22) was considered and rejected: a
+    # plain `GET` here is a client bug, and 404 vs 426 does not change what the
+    # client has to do.
     it "leaves a path served only by a WebSocket route as a 404" do
       error 404 do
         "not found"
@@ -657,6 +664,89 @@ describe "Kemal::RouteHandler" do
       response = call_request_on_app(HTTP::Request.new("GET", "/chat"))
       response.status_code.should eq(404)
       response.headers["Allow"]?.should be_nil
+    end
+
+    it "answers a non-GET request to a WebSocket only path with 405" do
+      ws "/chat" do |socket|
+        socket.send("hello")
+      end
+
+      response = call_request_on_app(HTTP::Request.new("POST", "/chat"))
+      response.status_code.should eq(405)
+      response.headers["Allow"].should eq("GET")
+    end
+
+    # The handshake is the only thing served on a WebSocket path, so `HEAD` is
+    # not offered there the way it is for a `GET` route.
+    it "does not advertise HEAD for a WebSocket only path" do
+      ws "/chat" do |socket|
+        socket.send("hello")
+      end
+
+      response = call_request_on_app(HTTP::Request.new("HEAD", "/chat"))
+      response.status_code.should eq(405)
+      response.headers["Allow"].should eq("GET")
+    end
+
+    it "matches path parameters when probing WebSocket routes" do
+      ws "/chat/:room" do |socket|
+        socket.send("hello")
+      end
+
+      response = call_request_on_app(HTTP::Request.new("DELETE", "/chat/general"))
+      response.status_code.should eq(405)
+      response.headers["Allow"].should eq("GET")
+    end
+
+    it "advertises the WebSocket handshake alongside the HTTP methods on the path" do
+      ws "/chat" do |socket|
+        socket.send("hello")
+      end
+      post "/chat" do
+        "post"
+      end
+
+      response = call_request_on_app(HTTP::Request.new("PUT", "/chat"))
+      response.status_code.should eq(405)
+      response.headers["Allow"].should eq("GET, POST")
+    end
+
+    it "leaves a plain GET on a path with a WebSocket and an HTTP route as a 404" do
+      error 404 do
+        "not found"
+      end
+      ws "/chat" do |socket|
+        socket.send("hello")
+      end
+      post "/chat" do
+        "post"
+      end
+
+      response = call_request_on_app(HTTP::Request.new("GET", "/chat"))
+      response.status_code.should eq(404)
+      response.headers["Allow"]?.should be_nil
+      response.body.should eq("not found")
+    end
+
+    it "still upgrades a WebSocket handshake on a path that also serves HTTP" do
+      ws "/chat" do |socket|
+        socket.send("hello")
+      end
+      post "/chat" do
+        "post"
+      end
+
+      headers = HTTP::Headers{
+        "Upgrade"               => "websocket",
+        "Connection"            => "Upgrade",
+        "Sec-WebSocket-Key"     => "dGhlIHNhbXBsZSBub25jZQ==",
+        "Sec-WebSocket-Version" => "13",
+        "Host"                  => "localhost",
+        "Origin"                => "http://localhost",
+      }
+      request = HTTP::Request.new("GET", "/chat", headers)
+      io, _ = create_ws_request_and_return_io_and_context(build_main_handler, request)
+      io.to_s.should contain("101 Switching Protocols")
     end
 
     it "does not put the probed methods into the route cache" do
@@ -731,6 +821,28 @@ describe "Kemal::RouteHandler" do
         end
 
         Kemal::RouteHandler::INSTANCE.allowed_methods("/other").should be_empty
+      end
+
+      # The verb index only tracks HTTP routes, so a WebSocket-only app leaves
+      # it empty. The probe has to sit outside that shortcut or such an app
+      # reports nothing at all.
+      it "reports GET for a WebSocket route in an app with no HTTP routes" do
+        ws "/chat" do |socket|
+          socket.send("hello")
+        end
+
+        Kemal::RouteHandler::INSTANCE.allowed_methods("/chat").should eq(["GET"])
+      end
+
+      it "reports GET once for a path carrying both a WebSocket and a GET route" do
+        ws "/chat" do |socket|
+          socket.send("hello")
+        end
+        get "/chat" do
+          "get"
+        end
+
+        Kemal::RouteHandler::INSTANCE.allowed_methods("/chat").should eq(["GET", "HEAD"])
       end
     end
   end

--- a/spec/websocket_handler_spec.cr
+++ b/spec/websocket_handler_spec.cr
@@ -33,9 +33,9 @@ def assert_websocket_forbidden_closed(response : HTTP::Client::Response)
   response.headers["Connection"]?.try(&.downcase).should eq("close")
 end
 
-def assert_websocket_method_not_allowed(response : HTTP::Client::Response)
+def assert_websocket_method_not_allowed(response : HTTP::Client::Response, allow : String = "GET")
   response.status_code.should eq(405)
-  response.headers["Allow"]?.should eq("GET")
+  response.headers["Allow"]?.should eq(allow)
   response.headers["Connection"]?.try(&.downcase).should eq("close")
   response.headers["Content-Type"]?.should eq("text/plain; charset=UTF-8")
   response.body.should eq("Method Not Allowed")
@@ -132,6 +132,39 @@ describe "Kemal::WebSocketHandler" do
         request = HTTP::Request.new(method, "/chat", headers)
         assert_websocket_method_not_allowed(call_ws_handler_response(handler, request))
       end
+    end
+
+    # `Allow` describes the resource, not this request, so the HTTP routes on the
+    # path belong in it too - hardcoding `GET` sent clients away from a verb the
+    # path really serves.
+    it "lists the HTTP methods on the path alongside the handshake verb" do
+      handler = Kemal::WebSocketHandler::INSTANCE
+      handler.next = Kemal::RouteHandler::INSTANCE
+      ws "/chat" { }
+      post "/chat" { "post" }
+      headers = ws_upgrade_headers_for_origin("http://localhost")
+      request = HTTP::Request.new("POST", "/chat", headers)
+      assert_websocket_method_not_allowed(call_ws_handler_response(handler, request), allow: "GET, POST")
+    end
+
+    it "lists them for a verb the path does not serve either" do
+      handler = Kemal::WebSocketHandler::INSTANCE
+      handler.next = Kemal::RouteHandler::INSTANCE
+      ws "/chat" { }
+      post "/chat" { "post" }
+      headers = ws_upgrade_headers_for_origin("http://localhost")
+      request = HTTP::Request.new("PUT", "/chat", headers)
+      assert_websocket_method_not_allowed(call_ws_handler_response(handler, request), allow: "GET, POST")
+    end
+
+    it "includes HEAD when the path also has a GET route" do
+      handler = Kemal::WebSocketHandler::INSTANCE
+      handler.next = Kemal::RouteHandler::INSTANCE
+      ws "/chat" { }
+      get "/chat" { "get" }
+      headers = ws_upgrade_headers_for_origin("http://localhost")
+      request = HTTP::Request.new("POST", "/chat", headers)
+      assert_websocket_method_not_allowed(call_ws_handler_response(handler, request), allow: "GET, HEAD")
     end
 
     it "rejects a non-GET upgrade with 405 before the Origin check" do

--- a/src/kemal/route_handler.cr
+++ b/src/kemal/route_handler.cr
@@ -221,24 +221,42 @@ module Kemal
     # are the two supported ways routes get in. A route pushed straight into the
     # tree through the `routes` getter bypasses both; that path degrades to the
     # pre-405 answer of `404` rather than reporting a wrong `Allow`.
+    #
+    # A `ws` route is reported as `GET`: the opening handshake is a `GET`
+    # (RFC 6455 §4.1), so a path carrying one does support the method. It gets
+    # no `HEAD` - the upgrade is the only thing served there, and
+    # `Kemal::WebSocketHandler` answers nothing else. The probe sits outside the
+    # `@registered_methods` shortcut above because that index only tracks HTTP
+    # routes, so a WebSocket-only app would otherwise report nothing at all. It
+    # is skipped once an HTTP route has already put `GET` in the list.
+    #
+    # It adds one lookup in a separate, WebSocket-only tree to every miss:
+    # measured at ~40ns on top of the ~490ns a two-verb probe already costs
+    # (Crystal 1.21, --release, Apple M-series), and unchanged whether or not
+    # the app registers any `ws` routes.
     def allowed_methods(path : String) : Array(String)
       methods = [] of String
-      return methods if @registered_methods.empty?
 
-      {% for method in HTTP_METHODS %}
-        if @registered_methods.includes?({{ method.upcase }}) && @routes.find(radix_path({{ method.upcase }}, path)).found?
-          methods << {{ method.upcase }}
-          {% if method == "get" %}
-            methods << "HEAD"
-          {% end %}
+      unless @registered_methods.empty?
+        {% for method in HTTP_METHODS %}
+          if @registered_methods.includes?({{ method.upcase }}) && @routes.find(radix_path({{ method.upcase }}, path)).found?
+            methods << {{ method.upcase }}
+            {% if method == "get" %}
+              methods << "HEAD"
+            {% end %}
+          end
+        {% end %}
+
+        # There is no `head` route DSL verb, but `add_route` accepts one, so a
+        # `HEAD` route standing on its own still has to be advertised.
+        if !methods.includes?("HEAD") && @registered_methods.includes?("HEAD") &&
+           @routes.find(radix_path("HEAD", path)).found?
+          methods << "HEAD"
         end
-      {% end %}
+      end
 
-      # There is no `head` route DSL verb, but `add_route` accepts one, so a
-      # `HEAD` route standing on its own still has to be advertised.
-      if !methods.includes?("HEAD") && @registered_methods.includes?("HEAD") &&
-         @routes.find(radix_path("HEAD", path)).found?
-        methods << "HEAD"
+      if !methods.includes?("GET") && Kemal::WebSocketHandler::INSTANCE.lookup_ws_route(path).found?
+        methods.unshift("GET")
       end
 
       methods
@@ -256,7 +274,14 @@ module Kemal
         # RFC 9110 §15.5.6: an existing resource that does not support the
         # request method is a 405, not a 404.
         allowed = allowed_methods(context.request.path)
-        raise Kemal::Exceptions::MethodNotAllowed.new(context, allowed) unless allowed.empty?
+        # A method that is itself allowed cannot be the reason this missed, so
+        # answering "405, Allow: GET" to a `GET` would be nonsense. This happens
+        # on a `ws` path reached without an `Upgrade` header: the handshake verb
+        # is allowed there, this particular request just is not a handshake.
+        # Falls through to the 404 that predates 405 handling.
+        unless allowed.empty? || allowed.includes?(context.request.method)
+          raise Kemal::Exceptions::MethodNotAllowed.new(context, allowed)
+        end
         raise Kemal::Exceptions::RouteNotFound.new(context)
       end
 

--- a/src/kemal/websocket_handler.cr
+++ b/src/kemal/websocket_handler.cr
@@ -111,8 +111,22 @@ module Kemal
     end
 
     # RFC 6455 §4.1 requires the opening handshake to be a GET request.
+    #
+    # `Allow` lists what the *resource* supports (RFC 9110 §10.2.1), not what
+    # would have satisfied this particular request, so it has to name the HTTP
+    # routes on the path too. Hardcoding `GET` here dropped them: with
+    # `ws "/chat"` and `post "/chat"`, a `POST` upgrade attempt was answered
+    # `Allow: GET` even though `POST` is served there. `allowed_methods` already
+    # probes both trees and reports the `ws` route as `GET`, so it is the one
+    # place that knows the full set.
     private def reject_websocket_method_not_allowed!(context : HTTP::Server::Context)
-      context.response.headers["Allow"] = "GET"
+      allowed = Kemal::RouteHandler::INSTANCE.allowed_methods(context.request.path)
+      # Unreachable while this is only called behind `ws_route_found?` - the same
+      # lookup `allowed_methods` makes - but an empty `Allow` would contradict
+      # the 405 it accompanies, so fall back to the handshake verb rather than
+      # send one. Mirrors the guard in `Kemal::ExceptionHandler`.
+      allowed = ["GET"] if allowed.empty?
+      context.response.headers["Allow"] = allowed.join(", ")
       reject_websocket!(context, :method_not_allowed)
     end
 


### PR DESCRIPTION
Hey @sdogruyol 
Here's a follow-up PR for issue #786!

### Description of the Change

`Kemal::WebSocketHandler` and `Kemal::RouteHandler` keep separate radix trees, and `allowed_methods` (added in #786) only probed the HTTP one. A WebSocket handshake is a `GET` (RFC 6455 §4.1), so a path with a `ws` route does support `GET`. Missing that produced two defects:

| request                 | before                                      | after                   |
| ----------------------- | ------------------------------------------- | ----------------------- |
| ws-only + `POST`        | 404 (empty 200 with no `error 404` handler) | 405, `Allow: GET`       |
| ws-only + plain `GET`   | 404                                         | 404 (unchanged)         |
| ws + post + `PUT`       | 405, `Allow: POST`                          | 405, `Allow: GET, POST` |
| ws + post + plain `GET` | 405, `Allow: POST`                          | 404                     |

Row 1 is pre-existing: a non-upgrade request falls through `WebSocketHandler` via `call_next`, misses the route lookup, and lands in the 404 branch. Row 3 is a regression introduced by #786.

Two changes in `route_handler.cr`:

1. **`allowed_methods` also probes the WebSocket tree.** The `@registered_methods.empty?` early return became an `unless` wrapper around the HTTP-verb loop, so the WebSocket probe still runs. That verb index only tracks HTTP routes, and a WebSocket-only app has none, so an early return would mean such an app never reports anything. On a hit it does `methods.unshift("GET")`, which keeps the documented `Allow` ordering (`GET, POST`). No `HEAD` is added: the handshake is the only thing served on a `ws` path.

2. **A guard in `process_request`.** A request whose own method is already in the allowed list cannot be the reason the lookup missed, so it is not a 405 — answering `405, Allow: GET` to a `GET` would be nonsense. A plain `GET` on a `ws` path is a handshake missing its `Upgrade` header, and now falls through to the same 404 it got before #786.

### Alternate Designs

- **Answer the 405 inside `WebSocketHandler`.** It already rejects non-GET *upgrade* requests with `405, Allow: GET` (`reject_websocket_method_not_allowed!`), so extending that to non-upgrade requests looked natural. Rejected: that handler cannot see the HTTP tree, so `ws "/chat"` + `post "/chat"` would answer `Allow: GET` and silently drop `POST`. Collecting both verb sets in one place is the only way to emit a truthful `Allow`.
- **Keep a `Set` of registered `ws` paths instead of probing the tree.** Rejected: it would not match path parameters (`ws "/chat/:room"`), and the measured probe cost does not justify the extra state.
- **Advertise `HEAD` alongside the `ws` `GET`.** Rejected: nothing serves `HEAD` there.
- **`426 Upgrade Required` for a plain `GET` on a `ws` path.** Arguably more accurate than 404 per RFC 9110 §15.5.22, but it is a separate behavior change with its own compatibility surface. Deliberately left out — I would rather have a maintainer weigh in first. Noted as open in the CHANGELOG and in a spec comment.

### Benefits

- A WebSocket-only path answers wrong-method requests per RFC 9110 §15.5.6 instead of a 404 — or, with no `error 404` handler registered, an empty `200`.
- Fixes the #786 regression where `Allow` omitted the verb that actually serves the path, which would send a client away from a working endpoint.
- The guard makes `Allow` self-consistent: the header can no longer list the very method being rejected.
- Costs one radix lookup in a separate tree per miss: **~40 ns** on top of the ~490 ns a two-verb probe already costs (Crystal 1.21, `--release`, Apple M-series, best of 3 × 3M iterations). Flat regardless of WebSocket tree size — an empty tree and a 3-route tree both bail at the root — so apps with no `ws` routes pay the same 40 ns.

### Possible Drawbacks

- **`HEAD` on a `ws`-only path changes from 404 to `405, Allow: GET`.** This is beyond the four rows above and follows from not advertising `HEAD` for a `ws` route, plus the guard (`HEAD` is not in the list, so it is not exempted). Covered by a spec; easy to special-case if you would rather it stayed a 404.
- **`ws` paths now confirm their own existence to a scanner**, the same over-approximation #786 already introduced for HTTP paths. The README note about putting auth in `before_all` rather than a path-scoped filter applies to them too.
- `allowed_methods` is public API and its return value now includes a WebSocket-derived `GET`. Anything calling it directly to enumerate *HTTP* routes will see one extra entry.
- The `426` question stays unresolved, so a plain `GET` on a `ws` path still answers a 404 that does not really explain what went wrong.