### PR TITLE
Compare the pre-compressed range body by bytes, not characters

### DIFF
--- a/spec/static_file_handler_spec.cr
+++ b/spec/static_file_handler_spec.cr
@@ -257,7 +257,10 @@ describe Kemal::StaticFileHandler do
         response.status_code.should eq(206)
         response.headers["Content-Encoding"].should eq "gzip"
         response.headers["Content-Range"].should eq "bytes 0-9/#{gz_size}"
-        response.body.should eq full.body[0, 10]
+        # Bytes, not characters: the gzip header carries a timestamp that differs per
+        # run, and when those bytes happen to form multibyte sequences a `String`
+        # slice of ten characters is not ten bytes.
+        response.body.to_slice.should eq full.body.to_slice[0, 10]
         response.headers["Etag"].should end_with %(-gzip")
       end
     end


### PR DESCRIPTION
Test-only. Fixes the flake that failed `static_file_handler_spec.cr:187` on macOS 1.19.2 and Windows 1.17.1/1.18.2 in #797's CI run, and once in five local runs on master.

### What was wrong

```crystal
response.body.should eq full.body[0, 10]
```

`String#[start, count]` slices **characters**. The gzip header is `1f 8b 08 00 <4-byte mtime> 00 ff …`; the mtime changes every run, and when its bytes happen to form valid multibyte UTF-8 sequences, ten characters of the body is more than ten bytes. The `206` response was correct — ten bytes — and did not equal a twelve-byte expectation. CI output from the failing run shows exactly that: expected `…\xFF}\xDA`, got `…\xFF`.

Reproduced deterministically with a header whose mtime bytes are `E1 89 9E 6A`: `full[0, 10].bytesize` is 12, `full.to_slice[0, 10].size` is 10.

### Change

Compare `to_slice`s. One line plus a comment saying why.

The same commit is carried on #797 so that PR's CI can go green; whichever merges first, the other rebases clean.
